### PR TITLE
[NLU-2583] recognizers-text-suite-genesys library is not being built correctly

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.0a1'
+VERSION = '1.0.4a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.0a1'
+VERSION = '1.0.4a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.0a1'
+VERSION = '1.0.4a0'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.0a1"
+VERSION = "1.0.4a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.0a1"
+VERSION = "1.0.4a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.0a1"
+VERSION = "1.0.4a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,9 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.0a1'
-REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'recognizers-text-number-with-unit-genesys',
-            'recognizers-text-date-time-genesys', 'recognizers-text-sequence-genesys', 'recognizers-text-choice-genesys']
+VERSION = '1.0.4a0'
+REQUIRES = [
+    'recognizers-text-genesys==1.0.4a0',
+    'recognizers-text-number-genesys==1.0.4a0',
+    'recognizers-text-number-with-unit-genesys==1.0.4a0',
+    'recognizers-text-date-time-genesys==1.0.4a0',
+    'recognizers-text-sequence-genesys==1.0.4a0',
+    'recognizers-text-choice-genesys==1.0.4a0'
+]
 
 setup(
     name=NAME,

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.0a1"
+VERSION = "1.0.4a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(


### PR DESCRIPTION
* Added `__init__.py` to `Python/libraries/recognizers-text/recognizers_text/matcher/` to make it a Python package.
* Version bump to `1.0.4a0`
* Pinned `recognizers-suite` dependencies, just in case.