### PR TITLE
NLU 2602 merged number extractor

### DIFF
--- a/Python/libraries/recognizers-number/recognizers_number/number/english/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/english/extractors.py
@@ -8,7 +8,7 @@ from recognizers_text.utilities import RegExpUtility
 from recognizers_number.number.models import NumberMode, LongFormatMode
 from recognizers_number.resources import BaseNumbers
 from recognizers_number.resources.english_numeric import EnglishNumeric
-from recognizers_number.number.extractors import ReVal, ReRe, BaseNumberExtractor, BasePercentageExtractor
+from recognizers_number.number.extractors import ReVal, ReRe, BaseNumberExtractor, BasePercentageExtractor, BaseMergedNumberExtractor
 from recognizers_number.number.constants import Constants
 
 
@@ -252,3 +252,17 @@ class EnglishPercentageExtractor(BasePercentageExtractor):
             EnglishNumeric.NumberWithSuffixPercentage,
             EnglishNumeric.NumberWithPrefixPercentage
         ]
+
+
+class EnglishMergedNumberExtractor(BaseMergedNumberExtractor):
+
+    @property
+    def _round_number_integer_regex_with_locks(self) -> Pattern:
+        return RegExpUtility.get_safe_reg_exp(EnglishNumeric.RoundNumberIntegerRegexWithLocks)
+
+    @property
+    def _connector_regex(self) -> Pattern:
+        return RegExpUtility.get_safe_reg_exp(EnglishNumeric.ConnectorRegex)
+
+    def __init__(self, mode: NumberMode = NumberMode.DEFAULT):
+        self._number_extractor = EnglishNumberExtractor(mode)

--- a/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
@@ -360,7 +360,7 @@ class BaseMergedNumberExtractor(Extractor):
                 else:
                     result[group].data = [ers[idx + 1]]
 
-        for idx in range(len(ers) - 1):
+        for idx in range(len(result)):
             inner_data = result[idx].data
             if inner_data and len(inner_data) == 1:
                 result[idx] = inner_data[0]

--- a/Python/libraries/recognizers-number/recognizers_number/number/german/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/german/extractors.py
@@ -8,7 +8,7 @@ from recognizers_text.utilities import RegExpUtility
 from recognizers_number.number.models import NumberMode, LongFormatMode
 from recognizers_number.resources import BaseNumbers
 from recognizers_number.resources.german_numeric import GermanNumeric
-from recognizers_number.number.extractors import ReVal, ReRe, BaseNumberExtractor, BasePercentageExtractor
+from recognizers_number.number.extractors import ReVal, ReRe, BaseNumberExtractor, BasePercentageExtractor, BaseMergedNumberExtractor
 from recognizers_number.number.constants import Constants
 
 
@@ -252,3 +252,17 @@ class GermanPercentageExtractor(BasePercentageExtractor):
             GermanNumeric.NumberWithSuffixPercentage,
             GermanNumeric.NumberWithPrefixPercentage
         ]
+
+
+class GermanMergedNumberExtractor(BaseMergedNumberExtractor):
+
+    @property
+    def _round_number_integer_regex_with_locks(self) -> Pattern:
+        return RegExpUtility.get_safe_reg_exp(GermanNumeric.RoundNumberIntegerRegexWithLocks)
+
+    @property
+    def _connector_regex(self) -> Pattern:
+        return RegExpUtility.get_safe_reg_exp(GermanNumeric.ConnectorRegex)
+
+    def __init__(self, mode: NumberMode = NumberMode.DEFAULT):
+        self._number_extractor = GermanNumberExtractor(mode)


### PR DESCRIPTION
Adding the MergedNumberExtractor to the number recognizer. 

Note only added for the languages that had the `RoundNumberIntegerRegexWithLocks` & `ConnectorRegex` specified in their resources (resources probably need updating).

It's not hooked up for use as requires a parser update to work correctly. To use the `EnglishNumberExtractor` requires replacing in the `number_recognizer` module when registering models: e.g.

```
        # region English
        self.register_model('NumberModel', Culture.English, lambda options: NumberModel(
            AgnosticNumberParserFactory.get_parser(
                ParserType.NUMBER, EnglishNumberParserConfiguration()),
            EnglishNumberExtractor(NumberMode.PURE_NUMBER)
        ))
```