### PR TITLE
NLU-2599-fix - Amending change in 2599 due to errors

### DIFF
--- a/Patterns/Japanese/Japanese-NumbersWithUnit.yaml
+++ b/Patterns/Japanese/Japanese-NumbersWithUnit.yaml
@@ -616,7 +616,7 @@ CurrencyAmbiguousValues: !list
     - レク
     - プル
     - ブル
-    - \
+    - \\
 AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:


### PR DESCRIPTION
Fix for the following error:

```python
File "/var/build/workspace/NLU/Recognizers-Text/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/resources/japanese_numeric_with_unit.py", line 517
  CurrencyAmbiguousValues = [r'円', r'銭', r'分', r'レク', r'プル', r'ブル', r'\']
                                                                        ^
SyntaxError: EOL while scanning string literal
```