### PR TITLE
NLU-2602-fix - Amending change in 2602 due to errors

### DIFF
--- a/Python/tests/test_initialization_number_recognizer.py
+++ b/Python/tests/test_initialization_number_recognizer.py
@@ -7,7 +7,7 @@ from recognizers_number.number import NumberOptions, NumberModel, NumberRecogniz
 from recognizers_number.number.models import NumberMode
 from recognizers_number.number.parsers import BaseNumberParser
 from recognizers_number.number.parser_factory import ParserType, AgnosticNumberParserFactory
-from recognizers_number.number.english.extractors import EnglishIntegerExtractor, EnglishNumberExtractor
+from recognizers_number.number.english.extractors import EnglishIntegerExtractor, EnglishMergedNumberExtractor
 from recognizers_number.number.english.parsers import EnglishNumberParserConfiguration
 
 
@@ -15,7 +15,7 @@ class TestInitializationNumberRecognizer():
     control_model = NumberModel(
         AgnosticNumberParserFactory.get_parser(
             ParserType.NUMBER, EnglishNumberParserConfiguration()),
-        EnglishNumberExtractor(NumberMode.PURE_NUMBER))
+        EnglishMergedNumberExtractor(NumberMode.PURE_NUMBER))
     english_culture = Culture.English
     spanish_culture = Culture.Spanish
     invalid_culture = "vo-id"


### PR DESCRIPTION
Fix for the following error:

```python
self = <test_initialization_number_recognizer.TestInitializationNumberRecognizer object at 0x7ffb8ab8e490>, expected = <recognizers_number.number.models.NumberModel object at 0x7ffb8940fd30>
actual = <recognizers_number.number.models.NumberModel object at 0x7ffb8aba37c0>

    def assert_models_equal(self, expected, actual):
        assert actual.model_type_name == expected.model_type_name
>       assert isinstance(actual.extractor, type(expected.extractor))
E       AssertionError: assert False
E        +  where False = isinstance(<recognizers_number.number.english.extractors.EnglishMergedNumberExtractor object at 0x7ffb8aba3490>, <class 'recognizers_number.number.english.extractors.EnglishNumberExtractor'>)
E        +    where <recognizers_number.number.english.extractors.EnglishMergedNumberExtractor object at 0x7ffb8aba3490> = <recognizers_number.number.models.NumberModel object at 0x7ffb8aba37c0>.extractor
E        +    and   <class 'recognizers_number.number.english.extractors.EnglishNumberExtractor'> = type(<recognizers_number.number.english.extractors.EnglishNumberExtractor object at 0x7ffb892efee0>)
E        +      where <recognizers_number.number.english.extractors.EnglishNumberExtractor object at 0x7ffb892efee0> = <recognizers_number.number.models.NumberModel object at 0x7ffb8940fd30>.extractor

tests/test_initialization_number_recognizer.py:25: AssertionError
```