### PR TITLE
NLU-2995: Update the Date Time parser to handle more cases and match .NET implementation

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'datatypes_timex_expression_genesys'
 
-VERSION = '1.0.20'
+VERSION = '1.0.21'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'recognizers-text-choice-genesys'
 
-VERSION = '1.0.20'
+VERSION = '1.0.21'
 
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
@@ -834,6 +834,11 @@ class DateParserConfiguration(ABC):
 
     @property
     @abstractmethod
+    def week_day_and_day_regex(self) -> Pattern:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def relative_month_regex(self) -> Pattern:
         raise NotImplementedError
 
@@ -1147,6 +1152,84 @@ class BaseDateParser(DateTimeParser):
             date = datetime(year, month, day)
             result.future_value = date
             result.past_value = date
+            result.success = True
+
+            return result
+
+        # Handling cases like 'Monday 21', which both 'Monday' and '21' refer to the same date.
+        # The year of expected date can be different to the year of referenceDate.
+        match = regex.match(
+            self.config.week_day_and_day_regex, trimmed_source)
+        if match:
+            # avoid parsing "Monday 3" from "Monday 3 weeks from now"
+            after_str = trimmed_source[match.end():]
+            if self.config.unit_regex.search(after_str.strip()):
+                return result
+
+            month = reference.month
+            year = reference.year
+
+            day_str = match.group(Constants.DAY_GROUP_NAME)
+            er = ExtractResult.get_from_text(day_str)
+
+            # Parse the day in text into number
+            day = int(self.config.number_parser.parse(er).value)
+
+            # Firstly, find a latest date with the "day" as pivotDate.
+            # Secondly, if the pivotDate equals the referenced date, in other word, the day of the referenced date is exactly the "day".
+            # In this way, check if the pivotDate is the weekday. If so, then the futureDate and the previousDate are the same date (referenced date).
+            # Otherwise, increase the pivotDate month by month to find the latest futureDate and decrease the pivotDate month
+            # by month to the latest previousDate.
+            # Notice: if the "day" is larger than 28, some months should be ignored in the increase or decrease procedure.
+            days_in_month = calendar.monthrange(year, month)[1]
+            if days_in_month >= day:
+                pivot_date = DateUtils.safe_create_from_min_value(year, month, day)
+            else:
+                # Add 1 month is enough, since 1, 3, 5, 7, 8, 10, 12 months has 31 days
+                pivot_date = datetime(year, month, day) + datedelta(months=1)
+                pivot_date = DateUtils.safe_create_from_min_value(pivot_date.year, pivot_date.month, pivot_date.day)
+
+            num_week_day_int = pivot_date.isoweekday()
+            extracted_week_day_str = match.group(Constants.WEEKDAY_GROUP_NAME)
+            week_day = self.config.day_of_week.get(extracted_week_day_str)
+
+            if pivot_date != DateUtils.min_value:
+                if day == reference.day and num_week_day_int == week_day:
+                    # The referenceDate is the weekday and with the "day".
+                    result.future_value = datetime(year, month, day)
+                    result.past_value = datetime(year, month, day)
+                    result.timex = DateTimeFormatUtil.luis_date(year, month, day)
+                else:
+                    future_date = pivot_date
+                    past_date = pivot_date
+
+                    while future_date.isoweekday() != week_day or future_date.day != day or future_date < reference:
+                        # Increase the futureDate month by month to find the expected date (the "day" is the weekday) and
+                        # make sure the futureDate not less than the referenceDate.
+                        future_date += datedelta(months=1)
+                        tmp_days_in_month = calendar.monthrange(future_date.year, future_date.month)[1]
+                        if tmp_days_in_month >= day:
+                            # For months like January 31, after add 1 month, February 31 won't be returned, so the day should be revised ASAP.
+                            future_date = DateUtils.safe_create_from_value(DateUtils.min_value, future_date.year, future_date.month, day)
+
+                    result.future_value = future_date
+
+                    while past_date.isoweekday() != week_day or past_date.day != day or past_date > reference:
+                        # Decrease the pastDate month by month to find the expected date (the "day" is the weekday) and
+                        # make sure the pastDate not larger than the referenceDate.
+                        past_date += datedelta(months=-1)
+                        tmp_days_in_month = calendar.monthrange(past_date.year, future_date.month)[1]
+                        if tmp_days_in_month >= day:
+                            # For months like March 31, after minus 1 month, February 31 won't be returned, so the day should be revised ASAP.
+                            past_date = DateUtils.safe_create_from_value(DateUtils.min_value, past_date.year, past_date.month, day)
+
+                    result.past_value = past_date
+
+                    if week_day == 0:
+                        week_day = 7
+
+                    result.timex = f"XXXX-WXX-{week_day}"
+
             result.success = True
 
             return result

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/date_parser_config.py
@@ -119,6 +119,10 @@ class ChineseDateParserConfiguration(DateParserConfiguration):
         return None
 
     @property
+    def week_day_and_day_regex(self) -> Pattern:
+        return self._week_day_and_day_regex
+
+    @property
     def relative_month_regex(self) -> any:
         return None
 
@@ -216,6 +220,8 @@ class ChineseDateParserConfiguration(DateParserConfiguration):
         self._unit_map = ChineseDateTime.ParserConfigurationUnitMap
         self._week_day_of_month_regex = RegExpUtility.get_safe_reg_exp(
             ChineseDateTime.WeekDayOfMonthRegex)
+        self._week_day_and_day_regex = RegExpUtility.get_safe_reg_exp(
+            ChineseDateTime.WeekDayAndDayRegex)
         self._week_day_regex = RegExpUtility.get_safe_reg_exp(
             ChineseDateTime.WeekDayRegex)
         self._dynasty_year_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_parser_config.py
@@ -80,6 +80,10 @@ class EnglishDateParserConfiguration(DateParserConfiguration):
         return self._special_day_regex
 
     @property
+    def special_day_with_num_regex(self) -> Pattern:
+        return self._special_day_with_num_regex
+
+    @property
     def next_regex(self) -> Pattern:
         return self._next_regex
 
@@ -175,6 +179,8 @@ class EnglishDateParserConfiguration(DateParserConfiguration):
             EnglishDateTime.OnRegex)
         self._special_day_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.SpecialDayRegex)
+        self._special_day_with_num_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.SpecialDayWithNumRegex)
         self._next_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.NextDateRegex)
         self._unit_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_parser_config.py
@@ -116,6 +116,10 @@ class EnglishDateParserConfiguration(DateParserConfiguration):
         return self._week_day_and_day_of_month_regex
 
     @property
+    def week_day_and_day_regex(self) -> Pattern:
+        return self._week_day_and_day_regex
+
+    @property
     def relative_month_regex(self) -> Pattern:
         return self._relative_month_regex
 
@@ -185,6 +189,8 @@ class EnglishDateParserConfiguration(DateParserConfiguration):
             EnglishDateTime.ForTheRegex)
         self._week_day_and_day_of_month_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.WeekDayAndDayOfMonthRegex)
+        self._week_day_and_day_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.WeekDayAndDayRegex)
         self._relative_month_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.RelativeMonthRegex)
         self._utility_configuration = config.utility_configuration

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_parser_config.py
@@ -124,6 +124,10 @@ class EnglishDateParserConfiguration(DateParserConfiguration):
         return self._relative_month_regex
 
     @property
+    def relative_week_day_regex(self) -> Pattern:
+        return self._relative_week_day_regex
+
+    @property
     def utility_configuration(self) -> DateTimeUtilityConfiguration:
         return self._utility_configuration
 
@@ -193,6 +197,8 @@ class EnglishDateParserConfiguration(DateParserConfiguration):
             EnglishDateTime.WeekDayAndDayRegex)
         self._relative_month_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.RelativeMonthRegex)
+        self._relative_week_day_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.RelativeWeekDayRegex)
         self._utility_configuration = config.utility_configuration
         self._date_token_prefix = EnglishDateTime.DateTokenPrefix
         self._check_both_before_after = EnglishDateTime.CheckBothBeforeAfter

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/date_parser_config.py
@@ -117,6 +117,10 @@ class FrenchDateParserConfiguration(DateParserConfiguration):
         return self._week_day_and_day_of_month_regex
 
     @property
+    def week_day_and_day_regex(self) -> Pattern:
+        return self._week_day_and_day_regex
+
+    @property
     def relative_month_regex(self) -> Pattern:
         return self._relative_month_regex
 
@@ -171,6 +175,8 @@ class FrenchDateParserConfiguration(DateParserConfiguration):
             FrenchDateTime.ForTheRegex)
         self._week_day_and_day_of_month_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.WeekDayAndDayOfMonthRegex)
+        self._week_day_and_day_regex = RegExpUtility.get_safe_reg_exp(
+            FrenchDateTime.WeekDayAndDayRegex)
         self._relative_month_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.RelativeMonthRegex)
         self._relative_week_day_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/date_parser_config.py
@@ -81,6 +81,10 @@ class FrenchDateParserConfiguration(DateParserConfiguration):
         return self._special_day_regex
 
     @property
+    def special_day_with_num_regex(self) -> Pattern:
+        return self._special_day_with_num_regex
+
+    @property
     def next_regex(self) -> Pattern:
         return self._next_regex
 
@@ -153,7 +157,7 @@ class FrenchDateParserConfiguration(DateParserConfiguration):
         self._on_regex = RegExpUtility.get_safe_reg_exp(FrenchDateTime.OnRegex)
         self._special_day_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.SpecialDayRegex)
-        self._special_day_regex_with_num_regex = RegExpUtility.get_safe_reg_exp(
+        self._special_day_with_num_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.SpecialDayWithNumRegex)
         self._next_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.NextDateRegex)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/german/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/german/date_parser_config.py
@@ -109,6 +109,10 @@ class GermanDateParserConfiguration(DateParserConfiguration):
         return self._week_day_of_month_regex
 
     @property
+    def week_day_and_day_regex(self) -> Pattern:
+        return self._week_day_and_day_regex
+
+    @property
     def for_the_regex(self) -> Pattern:
         return self._for_the_regex
 
@@ -176,6 +180,8 @@ class GermanDateParserConfiguration(DateParserConfiguration):
             GermanDateTime.ForTheRegex)
         self._week_day_and_day_of_month_regex = RegExpUtility.get_safe_reg_exp(
             GermanDateTime.WeekDayAndDayOfMonthRegex)
+        self._week_day_and_day_regex = RegExpUtility.get_safe_reg_exp(
+            GermanDateTime.WeekDayAndDayRegex)
         self._relative_month_regex = RegExpUtility.get_safe_reg_exp(
             GermanDateTime.RelativeMonthRegex)
         self._relative_week_day_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/german/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/german/date_parser_config.py
@@ -81,6 +81,10 @@ class GermanDateParserConfiguration(DateParserConfiguration):
         return self._special_day_regex
 
     @property
+    def special_day_with_num_regex(self) -> Pattern:
+        return self._special_day_with_num_regex
+
+    @property
     def next_regex(self) -> Pattern:
         return self._next_regex
 
@@ -160,7 +164,7 @@ class GermanDateParserConfiguration(DateParserConfiguration):
         self._on_regex = RegExpUtility.get_safe_reg_exp(GermanDateTime.OnRegex)
         self._special_day_regex = RegExpUtility.get_safe_reg_exp(
             GermanDateTime.SpecialDayRegex)
-        self._special_day_regex_with_num_regex = RegExpUtility.get_safe_reg_exp(
+        self._special_day_with_num_regex = RegExpUtility.get_safe_reg_exp(
             GermanDateTime.SpecialDayWithNumRegex)
         self._next_regex = RegExpUtility.get_safe_reg_exp(
             GermanDateTime.NextDateRegex)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/italian/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/italian/date_parser_config.py
@@ -117,6 +117,10 @@ class ItalianDateParserConfiguration(DateParserConfiguration):
         return self._week_day_and_day_of_month_regex
 
     @property
+    def week_day_and_day_regex(self) -> Pattern:
+        return self._week_day_and_day_regex
+
+    @property
     def relative_month_regex(self) -> Pattern:
         return self._relative_month_regex
 
@@ -178,6 +182,8 @@ class ItalianDateParserConfiguration(DateParserConfiguration):
             ItalianDateTime.ForTheRegex)
         self._week_day_and_day_of_month_regex = RegExpUtility.get_safe_reg_exp(
             ItalianDateTime.WeekDayAndDayOfMonthRegex)
+        self._week_day_and_day_regex = RegExpUtility.get_safe_reg_exp(
+            ItalianDateTime.WeekDayAndDayRegex)
         self._relative_month_regex = RegExpUtility.get_safe_reg_exp(
             ItalianDateTime.RelativeMonthRegex)
         self._relative_week_day_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/italian/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/italian/date_parser_config.py
@@ -81,6 +81,10 @@ class ItalianDateParserConfiguration(DateParserConfiguration):
         return self._special_day_regex
 
     @property
+    def special_day_with_num_regex(self) -> Pattern:
+        return self._special_day_with_num_regex
+
+    @property
     def next_regex(self) -> Pattern:
         return self._next_regex
 
@@ -160,7 +164,7 @@ class ItalianDateParserConfiguration(DateParserConfiguration):
         self._on_regex = RegExpUtility.get_safe_reg_exp(ItalianDateTime.OnRegex)
         self._special_day_regex = RegExpUtility.get_safe_reg_exp(
             ItalianDateTime.SpecialDayRegex)
-        self._special_day_regex_with_num_regex = RegExpUtility.get_safe_reg_exp(
+        self._special_day_with_num_regex = RegExpUtility.get_safe_reg_exp(
             ItalianDateTime.SpecialDayWithNumRegex)
         self._next_regex = RegExpUtility.get_safe_reg_exp(
             ItalianDateTime.NextDateRegex)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/portuguese/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/portuguese/date_parser_config.py
@@ -117,6 +117,10 @@ class PortugueseDateParserConfiguration(DateParserConfiguration):
         return self._week_day_and_day_of_month_regex
 
     @property
+    def week_day_and_day_regex(self) -> Pattern:
+        return self._week_day_and_day_regex
+
+    @property
     def relative_month_regex(self) -> Pattern:
         return self._relative_month_regex
 
@@ -175,6 +179,8 @@ class PortugueseDateParserConfiguration(DateParserConfiguration):
             PortugueseDateTime.ForTheRegex)
         self._week_day_and_day_of_month_regex = RegExpUtility.get_safe_reg_exp(
             PortugueseDateTime.WeekDayAndDayOfMonthRegex)
+        self._week_day_and_day_regex = RegExpUtility.get_safe_reg_exp(
+            PortugueseDateTime.WeekDayAndDayRegex)
         self._relative_month_regex = RegExpUtility.get_safe_reg_exp(
             PortugueseDateTime.RelativeMonthRegex)
         self._utility_configuration = config.utility_configuration

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/portuguese/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/portuguese/date_parser_config.py
@@ -125,6 +125,10 @@ class PortugueseDateParserConfiguration(DateParserConfiguration):
         return self._relative_month_regex
 
     @property
+    def relative_week_day_regex(self) -> Pattern:
+        return self._relative_week_day_regex
+
+    @property
     def utility_configuration(self) -> DateTimeUtilityConfiguration:
         return self._utility_configuration
 
@@ -183,6 +187,8 @@ class PortugueseDateParserConfiguration(DateParserConfiguration):
             PortugueseDateTime.WeekDayAndDayRegex)
         self._relative_month_regex = RegExpUtility.get_safe_reg_exp(
             PortugueseDateTime.RelativeMonthRegex)
+        self._relative_week_day_regex = RegExpUtility.get_safe_reg_exp(
+            PortugueseDateTime.RelativeWeekDayRegex)
         self._utility_configuration = config.utility_configuration
         self._date_token_prefix = PortugueseDateTime.DateTokenPrefix
         self._check_both_before_after = PortugueseDateTime.CheckBothBeforeAfter

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/portuguese/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/portuguese/date_parser_config.py
@@ -81,6 +81,10 @@ class PortugueseDateParserConfiguration(DateParserConfiguration):
         return self._special_day_regex
 
     @property
+    def special_day_with_num_regex(self) -> Pattern:
+        return self._special_day_with_num_regex
+
+    @property
     def next_regex(self) -> Pattern:
         return self._next_regex
 
@@ -165,6 +169,8 @@ class PortugueseDateParserConfiguration(DateParserConfiguration):
             PortugueseDateTime.OnRegex)
         self._special_day_regex = RegExpUtility.get_safe_reg_exp(
             PortugueseDateTime.SpecialDayRegex)
+        self._special_day_with_num_regex = RegExpUtility.get_safe_reg_exp(
+            PortugueseDateTime.SpecialDayWithNumRegex)
         self._next_regex = RegExpUtility.get_safe_reg_exp(
             PortugueseDateTime.NextDateRegex)
         self._unit_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/date_parser_config.py
@@ -117,6 +117,10 @@ class SpanishDateParserConfiguration(DateParserConfiguration):
         return self._week_day_and_day_of_month_regex
 
     @property
+    def week_day_and_day_regex(self) -> Pattern:
+        return self._week_day_and_day_regex
+
+    @property
     def relative_month_regex(self) -> Pattern:
         return self._relative_month_regex
 
@@ -179,6 +183,8 @@ class SpanishDateParserConfiguration(DateParserConfiguration):
             SpanishDateTime.ForTheRegex)
         self._week_day_and_day_of_month_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.WeekDayAndDayOfMonthRegex)
+        self._week_day_and_day_regex = RegExpUtility.get_safe_reg_exp(
+            SpanishDateTime.WeekDayAndDayRegex)
         self._relative_month_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.RelativeMonthRegex)
         self._relative_week_day_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/date_parser_config.py
@@ -81,6 +81,10 @@ class SpanishDateParserConfiguration(DateParserConfiguration):
         return self._special_day_regex
 
     @property
+    def special_day_with_num_regex(self) -> Pattern:
+        return self._special_day_with_num_regex
+
+    @property
     def next_regex(self) -> Pattern:
         return self._next_regex
 
@@ -165,6 +169,8 @@ class SpanishDateParserConfiguration(DateParserConfiguration):
             SpanishDateTime.OnRegex)
         self._special_day_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.SpecialDayRegex)
+        self._special_day_with_num_regex = RegExpUtility.get_safe_reg_exp(
+            SpanishDateTime.SpecialDayWithNumRegex)
         self._next_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.NextDateRegex)
         self._unit_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = 'recognizers-text-date-time-genesys'
 
-VERSION = '1.0.20'
+VERSION = '1.0.21'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-with-unit-genesys"
 
-VERSION = "1.0.20"
+VERSION = "1.0.21"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-genesys"
 
-VERSION = "1.0.20"
+VERSION = "1.0.21"
 
 REQUIRES = ['recognizers-text-genesys', 'regex']
 

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-sequence-genesys"
 
-VERSION = "1.0.20"
+VERSION = "1.0.21"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,14 +11,14 @@ def read(fname):
 
 NAME = 'recognizers-text-suite-genesys'
 
-VERSION = '1.0.20'
+VERSION = '1.0.21'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.20',
-    'recognizers-text-number-genesys==1.0.20',
-    'recognizers-text-number-with-unit-genesys==1.0.20',
-    'recognizers-text-date-time-genesys==1.0.20',
-    'recognizers-text-sequence-genesys==1.0.20',
-    'recognizers-text-choice-genesys==1.0.20'
+    'recognizers-text-genesys==1.0.21',
+    'recognizers-text-number-genesys==1.0.21',
+    'recognizers-text-number-with-unit-genesys==1.0.21',
+    'recognizers-text-date-time-genesys==1.0.21',
+    'recognizers-text-sequence-genesys==1.0.21',
+    'recognizers-text-choice-genesys==1.0.21'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
 
-VERSION = "1.0.20"
+VERSION = "1.0.21"
 
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 

--- a/Python/tests/test_runner_datetime.py
+++ b/Python/tests/test_runner_datetime.py
@@ -162,6 +162,12 @@ def test_datetime_model(
             assert_model_resolution(actual_resolution_value, expected['Resolution']['values'], spec_info)
 
 
+def test_single_utterance():
+    res = recognize_datetime("two days from tomorrow", "en-us")
+    print(f"{res}")
+    assert res != []
+
+
 def get_props(results, prop):
     list_result = []
     for result in results:

--- a/Python/tests/test_runner_datetime.py
+++ b/Python/tests/test_runner_datetime.py
@@ -162,12 +162,6 @@ def test_datetime_model(
             assert_model_resolution(actual_resolution_value, expected['Resolution']['values'], spec_info)
 
 
-def test_single_utterance():
-    res = recognize_datetime("two days from tomorrow", "en-us")
-    print(f"{res}")
-    assert res != []
-
-
 def get_props(results, prop):
     list_result = []
     for result in results:

--- a/Specs/DateTime/English/DateExtractor.json
+++ b/Specs/DateTime/English/DateExtractor.json
@@ -1174,7 +1174,7 @@
   },
   {
     "Input": "We had a meeting 1 month 21 days ago",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "1 month 21 days ago",
@@ -1186,7 +1186,7 @@
   },
   {
     "Input": "i left here 2 years 1 month 21 days ago",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "2 years 1 month 21 days ago",
@@ -1198,7 +1198,7 @@
   },
   {
     "Input": "i will leve here 2 years 21 days later",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "2 years 21 days later",
@@ -1210,7 +1210,7 @@
   },
   {
     "Input": "i left here 1 month 2 years 21 days ago",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "1 month 2 years 21 days ago",
@@ -1225,7 +1225,7 @@
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "the 20th next month",
+        "Text": "20th next month",
         "Type": "date",
         "Start": 12,
         "Length": 19
@@ -1269,7 +1269,7 @@
   },
   {
     "Input": "on september the twenty-first nineteen seventy eight",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "september the twenty-first nineteen seventy eight",
@@ -1281,7 +1281,7 @@
   },
   {
     "Input": "on september 10, nineteen zero one",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "september 10, nineteen zero one",
@@ -1293,7 +1293,7 @@
   },
   {
     "Input": "on the tenth of september, two thousand",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "tenth of september, two thousand",
@@ -1327,7 +1327,6 @@
   },
   {
     "Input": "Are you available two sundays from now?",
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "two sundays from now",
@@ -1339,7 +1338,6 @@
   },
   {
     "Input": "Are you available two monday later?",
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "two monday later",
@@ -1351,7 +1349,7 @@
   },
   {
     "Input": "Are you available two days after today?",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "two days after today",
@@ -1363,7 +1361,7 @@
   },
   {
     "Input": "Are you available three weeks from tomorrow?",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "three weeks from tomorrow",
@@ -1375,7 +1373,7 @@
   },
   {
     "Input": "Where were you two days before yesterday?",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "two days before yesterday",
@@ -1390,7 +1388,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-14T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "this friday-jun-15",
@@ -1405,7 +1402,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-14T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "this friday(jun-15)",
@@ -1420,7 +1416,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-14T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "this friday (jun-15)",
@@ -1450,7 +1445,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "this friday",
@@ -1471,7 +1465,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "python,javascript",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "in 3 weeks",
@@ -1566,7 +1560,7 @@
   },
   {
     "Input": "i'll go back twenty second of june 2017",
-    "NotSupported": "python,javascript",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "twenty second of june 2017",
@@ -1578,7 +1572,7 @@
   },
   {
     "Input": "i'll go back twenty-second of june 2017",
-    "NotSupported": "python,javascript",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "twenty-second of june 2017",

--- a/Specs/DateTime/English/DateParser.json
+++ b/Specs/DateTime/English/DateParser.json
@@ -2468,7 +2468,6 @@
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "two days from tomorrow",
@@ -2492,7 +2491,6 @@
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "four days from yesterday",
@@ -2608,7 +2606,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "3-7-27",
@@ -2632,7 +2629,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "05/05/89",
@@ -2656,7 +2652,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "05/05/71",
@@ -2680,7 +2675,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-07T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "two sundays from now",
@@ -2704,7 +2698,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-07T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "two monday later",
@@ -2728,7 +2721,7 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "two days after today",
@@ -2800,7 +2793,7 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "in 3 weeks",
@@ -2848,7 +2841,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-21T08:00:00"
     },
-    "NotSupported": "python,javascript",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "twenty second of june 2017",
@@ -2918,7 +2911,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "java, javascript",
     "Results": [
       {
         "Text": "Feb 29",
@@ -2942,7 +2935,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "java, javascript",
     "Results": [
       {
         "Text": "2/29",
@@ -2966,7 +2959,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "java, javascript",
     "Results": [
       {
         "Text": "Feb 29th",


### PR DESCRIPTION
Updated the Date Parser to handle more uses cases that were implemented in .NET. Note the success of the different languages depends on the regex defined in the configurations of those languages.

e.g. the french configuration for SpecialDayWithNumRegex:
SpecialDayWithNumRegex = f'^\\b$'

But this PR covers bringing the parser up to-date with the .NET implementation and not updates to the regexes.