### PR TITLE
Spike for dealing with "Irish Dates"

### DIFF
--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -1344,5 +1344,6 @@ QuarterTypeRegex: !simpleRegex
 YearTypeRegex: !simpleRegex
   def: ((years?|annual)(ly)?)$
 IrishRegex: !nestedRegex
-  def: \b(3[0-1]|2[0-9]|1[0-9]|[0-9])(th|nd|st|rd)\s(of\s)(the\s)(1[1-2]|[0-9])(th|nd|st|rd)\s({YearRegex}|{TwoDigitYearRegex}?)\b
+  def: \b(3[0-1]|2[0-9]|1[0-9]|[0-9])(th|nd|st|rd)\s(of\s)(the\s)(1[1-2]|[0-9])(th|nd|st|rd)\s?({YearRegex}|{TwoDigitYearRegex})?\b
+  references: [ YearRegex, TwoDigitYearRegex ]
 ...

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -1343,4 +1343,6 @@ QuarterTypeRegex: !simpleRegex
   def: (quarter(s|ly)?)$
 YearTypeRegex: !simpleRegex
   def: ((years?|annual)(ly)?)$
+IrishRegex: !nestedRegex
+  def: \b(3[0-1]|2[0-9]|1[0-9]|[0-9])(th|nd|st|rd)\s(of\s)(the\s)(1[1-2]|[0-9])(th|nd|st|rd)\s({YearRegex}|{TwoDigitYearRegex}?)\b
 ...

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'datatypes_timex_expression_genesys'
 
-VERSION = '1.0.22a0'
+VERSION = '1.0.22a1'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'datatypes_timex_expression_genesys'
 
-VERSION = '1.0.21'
+VERSION = '1.0.22a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'recognizers-text-choice-genesys'
 
-VERSION = '1.0.22a0'
+VERSION = '1.0.22a1'
 
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'recognizers-text-choice-genesys'
 
-VERSION = '1.0.21'
+VERSION = '1.0.22a0'
 
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
@@ -880,7 +880,7 @@ class DateParserConfiguration(ABC):
         raise NotImplementedError
 
     @property
-    @abstractmethod
+    # @abstractmethod
     def irish_date(self) -> str:
         raise NotImplementedError
 
@@ -1297,27 +1297,30 @@ class BaseDateParser(DateTimeParser):
             return result
 
         # Handle nth of the nth
-        match = regex.match(self.config.irish_date, trimmed_source)
-        if match:
-            extract_results = self.config.ordinal_extractor.extract(source)
+        try:
+            match = regex.match(self.config.irish_date, trimmed_source)
+            if match:
+                extract_results = self.config.ordinal_extractor.extract(source)
 
-            day = int(self.config.number_parser.parse(extract_results[0]).value)
-            month = int(self.config.number_parser.parse(extract_results[1]).value)
-            year = reference.year
-            year_str = RegExpUtility.get_group(match, Constants.YEAR_GROUP_NAME)
-            if year_str:
-                year = int(year_str) if year_str.isnumeric() else 0
+                day = int(self.config.number_parser.parse(extract_results[0]).value)
+                month = int(self.config.number_parser.parse(extract_results[1]).value)
+                year = reference.year
+                year_str = RegExpUtility.get_group(match, Constants.YEAR_GROUP_NAME)
+                if year_str:
+                    year = int(year_str) if year_str.isnumeric() else 0
 
-                if 100 > year >= Constants.MIN_TWO_DIGIT_YEAR_PAST_NUM:
-                    year += 1900
-                elif 0 <= year < Constants.MAX_TWO_DIGIT_YEAR_FUTURE_NUM:
-                    year += 2000
+                    if 100 > year >= Constants.MIN_TWO_DIGIT_YEAR_PAST_NUM:
+                        year += 1900
+                    elif 0 <= year < Constants.MAX_TWO_DIGIT_YEAR_FUTURE_NUM:
+                        year += 2000
 
-            result.timex = DateTimeFormatUtil.luis_date(year, month, day)
-            date = datetime(year, month, day)
-            result.future_value = date
-            result.past_value = date
-            result.success = True
+                result.timex = DateTimeFormatUtil.luis_date(year, month, day)
+                date = datetime(year, month, day)
+                result.future_value = date
+                result.past_value = date
+                result.success = True
+        except NotImplementedError:
+            pass
 
         return result
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
@@ -879,6 +879,11 @@ class DateParserConfiguration(ABC):
     def check_both_before_after(self) -> bool:
         raise NotImplementedError
 
+    @property
+    @abstractmethod
+    def irish_date(self) -> str:
+        raise NotImplementedError
+
 
 class BaseDateParser(DateTimeParser):
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
@@ -1291,6 +1291,29 @@ class BaseDateParser(DateTimeParser):
 
             return result
 
+        # Handle nth of the nth
+        match = regex.match(self.config.irish_date, trimmed_source)
+        if match:
+            extract_results = self.config.ordinal_extractor.extract(source)
+
+            day = int(self.config.number_parser.parse(extract_results[0]).value)
+            month = int(self.config.number_parser.parse(extract_results[1]).value)
+            year = reference.year
+            year_str = RegExpUtility.get_group(match, Constants.YEAR_GROUP_NAME)
+            if year_str:
+                year = int(year_str) if year_str.isnumeric() else 0
+
+                if 100 > year >= Constants.MIN_TWO_DIGIT_YEAR_PAST_NUM:
+                    year += 1900
+                elif 0 <= year < Constants.MAX_TWO_DIGIT_YEAR_FUTURE_NUM:
+                    year += 2000
+
+            result.timex = DateTimeFormatUtil.luis_date(year, month, day)
+            date = datetime(year, month, day)
+            result.future_value = date
+            result.past_value = date
+            result.success = True
+
         return result
 
     def parse_weekday_of_month(self, source: str, reference: datetime) -> DateTimeParseResult:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_extractor_config.py
@@ -183,7 +183,9 @@ class EnglishDateExtractorConfiguration(DateExtractorConfiguration):
                 EnglishDateTime.WeekDayOfMonthRegex),
             RegExpUtility.get_safe_reg_exp(EnglishDateTime.SpecialDate),
             RegExpUtility.get_safe_reg_exp(EnglishDateTime.SpecialDayWithNumRegex),
-            RegExpUtility.get_safe_reg_exp(EnglishDateTime.RelativeWeekDayRegex)
+            RegExpUtility.get_safe_reg_exp(EnglishDateTime.RelativeWeekDayRegex),
+            RegExpUtility.get_safe_reg_exp(EnglishDateTime.IrishRegex)
+
         ]
         self._month_end = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.MonthEnd)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/date_parser_config.py
@@ -139,6 +139,10 @@ class EnglishDateParserConfiguration(DateParserConfiguration):
     def date_token_prefix(self) -> str:
         return self._date_token_prefix
 
+    @property
+    def irish_date(self) -> str:
+        return self._irish_date
+
     # The following three regexes only used in this configuration
     # They are not used in the base parser, therefore they are not extracted
     # If the spanish date parser need the same regexes, they should be extracted
@@ -208,6 +212,8 @@ class EnglishDateParserConfiguration(DateParserConfiguration):
         self._utility_configuration = config.utility_configuration
         self._date_token_prefix = EnglishDateTime.DateTokenPrefix
         self._check_both_before_after = EnglishDateTime.CheckBothBeforeAfter
+        self._irish_date = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.IrishRegex)
 
     def get_swift_day(self, source: str) -> int:
         trimmed_text = source.strip().lower()

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -747,5 +747,5 @@ class EnglishDateTime:
     MonthTypeRegex = f'(month(s|ly)?)$'
     QuarterTypeRegex = f'(quarter(s|ly)?)$'
     YearTypeRegex = f'((years?|annual)(ly)?)$'
-    IrishRegex = f'\\b(3[0-1]|2[0-9]|1[0-9]|[0-9])(th|nd|st|rd)\\s(of\\s)(the\\s)(1[1-2]|[0-9])(th|nd|st|rd)\\s({YearRegex}|{TwoDigitYearRegex}?)\\b'
+    IrishRegex = f'\\b(3[0-1]|2[0-9]|1[0-9]|[0-9])(th|nd|st|rd)\\s(of\\s)(the\\s)(1[1-2]|[0-9])(th|nd|st|rd)\\s({{YearRegex}}|{{TwoDigitYearRegex}}?)\\b'
 # pylint: enable=line-too-long

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -747,4 +747,5 @@ class EnglishDateTime:
     MonthTypeRegex = f'(month(s|ly)?)$'
     QuarterTypeRegex = f'(quarter(s|ly)?)$'
     YearTypeRegex = f'((years?|annual)(ly)?)$'
+    IrishRegex = f'\\b(3[0-1]|2[0-9]|1[0-9]|[0-9])(th|nd|st|rd)\\s(of\\s)(the\\s)(1[1-2]|[0-9])(th|nd|st|rd)\\s({YearRegex}|{TwoDigitYearRegex}?)\\b'
 # pylint: enable=line-too-long

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -747,5 +747,5 @@ class EnglishDateTime:
     MonthTypeRegex = f'(month(s|ly)?)$'
     QuarterTypeRegex = f'(quarter(s|ly)?)$'
     YearTypeRegex = f'((years?|annual)(ly)?)$'
-    IrishRegex = f'\\b(3[0-1]|2[0-9]|1[0-9]|[0-9])(th|nd|st|rd)\\s(of\\s)(the\\s)(1[1-2]|[0-9])(th|nd|st|rd)\\s({{YearRegex}}|{{TwoDigitYearRegex}}?)\\b'
+    IrishRegex = f'\\b(3[0-1]|2[0-9]|1[0-9]|[0-9])(th|nd|st|rd)\\s(of\\s)(the\\s)(1[1-2]|[0-9])(th|nd|st|rd)\\s?({YearRegex}|{TwoDigitYearRegex})?\\b'
 # pylint: enable=line-too-long

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = 'recognizers-text-date-time-genesys'
 
-VERSION = '1.0.22a0'
+VERSION = '1.0.22a1'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = 'recognizers-text-date-time-genesys'
 
-VERSION = '1.0.21'
+VERSION = '1.0.22a0'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-with-unit-genesys"
 
-VERSION = "1.0.21"
+VERSION = "1.0.22a0"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-with-unit-genesys"
 
-VERSION = "1.0.22a0"
+VERSION = "1.0.22a1"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-genesys"
 
-VERSION = "1.0.22a0"
+VERSION = "1.0.22a1"
 
 REQUIRES = ['recognizers-text-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-genesys"
 
-VERSION = "1.0.21"
+VERSION = "1.0.22a0"
 
 REQUIRES = ['recognizers-text-genesys', 'regex']
 

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-sequence-genesys"
 
-VERSION = "1.0.22a0"
+VERSION = "1.0.22a1"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-sequence-genesys"
 
-VERSION = "1.0.21"
+VERSION = "1.0.22a0"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,14 +11,14 @@ def read(fname):
 
 NAME = 'recognizers-text-suite-genesys'
 
-VERSION = '1.0.22a0'
+VERSION = '1.0.22a1'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.22a0',
-    'recognizers-text-number-genesys==1.0.22a0',
-    'recognizers-text-number-with-unit-genesys==1.0.22a0',
-    'recognizers-text-date-time-genesys==1.0.22a0',
-    'recognizers-text-sequence-genesys==1.0.22a0',
-    'recognizers-text-choice-genesys==1.0.22a0'
+    'recognizers-text-genesys==1.0.22a1',
+    'recognizers-text-number-genesys==1.0.22a1',
+    'recognizers-text-number-with-unit-genesys==1.0.22a1',
+    'recognizers-text-date-time-genesys==1.0.22a1',
+    'recognizers-text-sequence-genesys==1.0.22a1',
+    'recognizers-text-choice-genesys==1.0.22a1'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,14 +11,14 @@ def read(fname):
 
 NAME = 'recognizers-text-suite-genesys'
 
-VERSION = '1.0.21'
+VERSION = '1.0.22a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.21',
-    'recognizers-text-number-genesys==1.0.21',
-    'recognizers-text-number-with-unit-genesys==1.0.21',
-    'recognizers-text-date-time-genesys==1.0.21',
-    'recognizers-text-sequence-genesys==1.0.21',
-    'recognizers-text-choice-genesys==1.0.21'
+    'recognizers-text-genesys==1.0.22a0',
+    'recognizers-text-number-genesys==1.0.22a0',
+    'recognizers-text-number-with-unit-genesys==1.0.22a0',
+    'recognizers-text-date-time-genesys==1.0.22a0',
+    'recognizers-text-sequence-genesys==1.0.22a0',
+    'recognizers-text-choice-genesys==1.0.22a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
 
-VERSION = "1.0.22a0"
+VERSION = "1.0.22a1"
 
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
 
-VERSION = "1.0.21"
+VERSION = "1.0.22a0"
 
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 

--- a/Python/tests/run.py
+++ b/Python/tests/run.py
@@ -1,0 +1,18 @@
+# from recognizers_number.number.number_recognizer import recognize_number
+from recognizers_date_time.date_time.date_time_recognizer import recognize_datetime
+
+input_text = "6th of the 12th 1997"
+# input_text = "6th of December"
+# input_text = "Thursday the 6th"
+# input_text = "On the tenth"
+# input_text = "4th of the 3rd"
+culture = "en-us"
+results = recognize_datetime(input_text, culture)
+
+if not results:
+    print("No Results")
+for result in results:
+    print(result)
+    for value in result.resolution.get("values"):
+        print(value)
+


### PR DESCRIPTION
This is still a spike so some of the implementation is a little hacky and names (like Irish Regex) are up for grabs.

This work will resolve dates that are of the form "nth of the nth" I've not added any test cases just yet, but manual testing here and through the NLU repo include:

- 6th of the 12th: resolves to 2022-12-06
- 6th of the 12th 97: resolves to 1997-12-06
- 26th of the 12th 1947: resolves to 1947-12-26
- of the 12th: doesn't resolve
- This is the 6th of 12 sessions we’ll have: doesn't resolve

This is expected behaviour