### PR TITLE
[Bugfix/NLU-3061] "3 y medio" is resolved incorrectly

### DIFF
--- a/Patterns/Spanish/Spanish-Numbers.yaml
+++ b/Patterns/Spanish/Spanish-Numbers.yaml
@@ -139,7 +139,7 @@ RoundMultiplierRegex: !nestedRegex
   def: \b\s*({RoundMultiplierWithFraction}|(?<multiplier>(mil))$)
   references: [ RoundMultiplierWithFraction ]
 FractionNounRegex: !nestedRegex
-  def: (?<=\b)({AllIntRegex}\s+((y|con)\s+)?)?({AllIntRegex}\s+((({AllOrdinalNumberRegex}|{SufixRoundOrdinalRegex})s|{SpecialFractionInteger})|((y|con)\s+)?(medi[oa]s?|tercios?))|(medio|un\s+cuarto\s+de)\s+{RoundNumberIntegerRegex})(?=\b)
+  def: (?<=\b)(({AllIntRegex}|{DigitsNumberRegex})\s+((y|con)\s+)?)?(({AllIntRegex}|{DigitsNumberRegex})\s+((({AllOrdinalNumberRegex}|{SufixRoundOrdinalRegex})s|{SpecialFractionInteger})|((y|con)\s+)?(medi[oa]s?|tercios?))|(medio|un\s+cuarto\s+de)\s+{RoundNumberIntegerRegex})(?=\b)
   references: [ AllIntRegex, AllOrdinalNumberRegex, SpecialFractionInteger, SufixRoundOrdinalRegex, RoundNumberIntegerRegex ]
 FractionNounWithArticleRegex: !nestedRegex
   def: (?<=\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+((y|con)\s+)?)?((un|un[oa])(\s+)(({AllOrdinalNumberRegex})|({SufixRoundOrdinalRegex}))|(un[ao]?\s+)?medi[oa]s?|mitad)(?=\b)

--- a/Patterns/Spanish/Spanish-Numbers.yaml
+++ b/Patterns/Spanish/Spanish-Numbers.yaml
@@ -140,7 +140,7 @@ RoundMultiplierRegex: !nestedRegex
   references: [ RoundMultiplierWithFraction ]
 FractionNounRegex: !nestedRegex
   def: (?<=\b)(({AllIntRegex}|{DigitsNumberRegex})\s+((y|con)\s+)?)?(({AllIntRegex}|{DigitsNumberRegex})\s+((({AllOrdinalNumberRegex}|{SufixRoundOrdinalRegex})s|{SpecialFractionInteger})|((y|con)\s+)?(medi[oa]s?|tercios?))|(medio|un\s+cuarto\s+de)\s+{RoundNumberIntegerRegex})(?=\b)
-  references: [ AllIntRegex, AllOrdinalNumberRegex, SpecialFractionInteger, SufixRoundOrdinalRegex, RoundNumberIntegerRegex ]
+  references: [ DigitsNumberRegex, AllIntRegex, AllOrdinalNumberRegex, SpecialFractionInteger, SufixRoundOrdinalRegex, RoundNumberIntegerRegex ]
 FractionNounWithArticleRegex: !nestedRegex
   def: (?<=\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+((y|con)\s+)?)?((un|un[oa])(\s+)(({AllOrdinalNumberRegex})|({SufixRoundOrdinalRegex}))|(un[ao]?\s+)?medi[oa]s?|mitad)(?=\b)
   references: [ AllIntRegex, AllOrdinalNumberRegex, SufixRoundOrdinalRegex, RoundNumberIntegerRegexWithLocks ]

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'datatypes_timex_expression_genesys'
 
-VERSION = '1.0.26a0'
+VERSION = '1.0.26a1'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'datatypes_timex_expression_genesys'
 
-VERSION = '1.0.24'
+VERSION = '1.0.26a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'recognizers-text-choice-genesys'
 
-VERSION = '1.0.26a0'
+VERSION = '1.0.26a1'
 
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'recognizers-text-choice-genesys'
 
-VERSION = '1.0.24'
+VERSION = '1.0.26a0'
 
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -90,7 +90,7 @@ class EnglishDateTime:
     FollowedDateUnit = f'^\\s*{DateUnitRegex}'
     NumberCombinedWithDateUnit = f'\\b(?<num>\\d+(\\.\\d*)?){DateUnitRegex}'
     QuarterTermRegex = f'\\b(((?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)[ -]+quarter)|(q(?<number>[1-4])))\\b'
-    RelativeQuarterTermRegex = f'\\b(?<orderQuarter>{StrictRelativeRegex})\\s+quarter\\b'
+    RelativeQuarterTermRegex = f'\\b(?<orderQuarter>{StrictRelativeRegex})\\s+((?<num>[\\w,]+)\\s+)?quarters?\\b'
     QuarterRegex = f'((the\\s+)?{QuarterTermRegex}(?:((\\s+of)?\\s+|\\s*[,-]\\s*)({YearRegex}|{RelativeRegex}\\s+year))?)|{RelativeQuarterTermRegex}'
     QuarterRegexYearFront = f'(?:{YearRegex}|{RelativeRegex}\\s+year)(\'s)?(?:\\s*-\\s*|\\s+(the\\s+)?)?{QuarterTermRegex}'
     HalfYearTermRegex = f'(?<cardinal>first|1st|second|2nd)\\s+half'

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = 'recognizers-text-date-time-genesys'
 
-VERSION = '1.0.24'
+VERSION = '1.0.26a0'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = 'recognizers-text-date-time-genesys'
 
-VERSION = '1.0.26a0'
+VERSION = '1.0.26a1'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-with-unit-genesys"
 
-VERSION = "1.0.24"
+VERSION = "1.0.26a0"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-with-unit-genesys"
 
-VERSION = "1.0.26a0"
+VERSION = "1.0.26a1"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number/recognizers_number/resources/spanish_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/spanish_numeric.py
@@ -66,7 +66,7 @@ class SpanishNumeric:
     FractionMultiplierRegex = f'(?<fracMultiplier>\\s+(y|con)\\s+(medio|(un|{TwoToNineIntegerRegex})\\s+(medio|terci[oa]?|cuart[oa]|quint[oa]|sext[oa]|s[eé]ptim[oa]|octav[oa]|noven[oa]|d[eé]cim[oa])s?))'
     RoundMultiplierWithFraction = f'(?<multiplier>(?:(mil\\s+millones|mill[oó]n(es)?|bill[oó]n(es)?|trill[oó]n(es)?|cuatrill[oó]n(es)?|quintill[oó]n(es)?|sextill[oó]n(es)?|septill[oó]n(es)?)))(?={FractionMultiplierRegex}?$)'
     RoundMultiplierRegex = f'\\b\\s*({RoundMultiplierWithFraction}|(?<multiplier>(mil))$)'
-    FractionNounRegex = f'(?<=\\b)({AllIntRegex}\\s+((y|con)\\s+)?)?({AllIntRegex}\\s+((({AllOrdinalNumberRegex}|{SufixRoundOrdinalRegex})s|{SpecialFractionInteger})|((y|con)\\s+)?(medi[oa]s?|tercios?))|(medio|un\\s+cuarto\\s+de)\\s+{RoundNumberIntegerRegex})(?=\\b)'
+    FractionNounRegex = f'(?<=\\b)(({AllIntRegex}|{DigitsNumberRegex})\\s+((y|con)\\s+)?)?(({AllIntRegex}|{DigitsNumberRegex})\\s+((({AllOrdinalNumberRegex}|{SufixRoundOrdinalRegex})s|{SpecialFractionInteger})|((y|con)\\s+)?(medi[oa]s?|tercios?))|(medio|un\\s+cuarto\\s+de)\\s+{RoundNumberIntegerRegex})(?=\\b)'
     FractionNounWithArticleRegex = f'(?<=\\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\\s+((y|con)\\s+)?)?((un|un[oa])(\\s+)(({AllOrdinalNumberRegex})|({SufixRoundOrdinalRegex}))|(un[ao]?\\s+)?medi[oa]s?|mitad)(?=\\b)'
     FractionPrepositionRegex = f'(?<!{BaseNumbers.CommonCurrencySymbol}\\s*)(?<=\\b)(?<numerator>({AllIntRegex})|((?<!\\.)\\d+))\\s+sobre\\s+(?<denominator>({AllIntRegex})|((\\d+)(?!\\.)))(?=\\b)'
     AllPointRegex = f'((\\s+{ZeroToNineIntegerRegex})+|(\\s+{AllIntRegex}))'

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-genesys"
 
-VERSION = "1.0.26a0"
+VERSION = "1.0.26a1"
 
 REQUIRES = ['recognizers-text-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-genesys"
 
-VERSION = "1.0.24"
+VERSION = "1.0.26a0"
 
 REQUIRES = ['recognizers-text-genesys', 'regex']
 

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-sequence-genesys"
 
-VERSION = "1.0.24"
+VERSION = "1.0.26a0"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-sequence-genesys"
 
-VERSION = "1.0.26a0"
+VERSION = "1.0.26a1"
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,14 +11,14 @@ def read(fname):
 
 NAME = 'recognizers-text-suite-genesys'
 
-VERSION = '1.0.24'
+VERSION = '1.0.26a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.24',
-    'recognizers-text-number-genesys==1.0.24',
-    'recognizers-text-number-with-unit-genesys==1.0.24',
-    'recognizers-text-date-time-genesys==1.0.24',
-    'recognizers-text-sequence-genesys==1.0.24',
-    'recognizers-text-choice-genesys==1.0.24'
+    'recognizers-text-genesys==1.0.26a0',
+    'recognizers-text-number-genesys==1.0.26a0',
+    'recognizers-text-number-with-unit-genesys==1.0.26a0',
+    'recognizers-text-date-time-genesys==1.0.26a0',
+    'recognizers-text-sequence-genesys==1.0.26a0',
+    'recognizers-text-choice-genesys==1.0.26a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,14 +11,14 @@ def read(fname):
 
 NAME = 'recognizers-text-suite-genesys'
 
-VERSION = '1.0.26a0'
+VERSION = '1.0.26a1'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.26a0',
-    'recognizers-text-number-genesys==1.0.26a0',
-    'recognizers-text-number-with-unit-genesys==1.0.26a0',
-    'recognizers-text-date-time-genesys==1.0.26a0',
-    'recognizers-text-sequence-genesys==1.0.26a0',
-    'recognizers-text-choice-genesys==1.0.26a0'
+    'recognizers-text-genesys==1.0.26a1',
+    'recognizers-text-number-genesys==1.0.26a1',
+    'recognizers-text-number-with-unit-genesys==1.0.26a1',
+    'recognizers-text-date-time-genesys==1.0.26a1',
+    'recognizers-text-sequence-genesys==1.0.26a1',
+    'recognizers-text-choice-genesys==1.0.26a1'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
 
-VERSION = "1.0.26a0"
+VERSION = "1.0.26a1"
 
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
 
-VERSION = "1.0.24"
+VERSION = "1.0.26a0"
 
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 

--- a/Specs/Number/Spanish/NumberModel.json
+++ b/Specs/Number/Spanish/NumberModel.json
@@ -3284,6 +3284,7 @@
         "Text": "3 y medio",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "3,5"
         },
         "Start": 0,

--- a/Specs/Number/Spanish/NumberModel.json
+++ b/Specs/Number/Spanish/NumberModel.json
@@ -3275,5 +3275,20 @@
   {
     "Input": "billons",
     "Results": []
+  },
+  {
+    "Input": "3 y medio",
+    "NotSupported": "java, javascript",
+    "Results": [
+      {
+        "Text": "3 y medio",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3,5"
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
   }
 ]


### PR DESCRIPTION
**Issue:**
Not resolving “3 y medio“ (three and a half) correctly in ES.
It is resolved as two separate entities - “3” and “0.5” instead of “3.5”

This fix represents a small drift from MS .NET implementation i.e. .NET is unable to handle cases of number input where it is digit+"and a half".