### PR TITLE
[NLU-3222] V3 Entity Improvement: EN-US time: 10 past 3

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string LunchRegex = @"\blunchtime\b";
       public const string NightRegex = @"\b(mid)?night\b";
       public const string CommonDatePrefixRegex = @"^[\.]";
-      public static readonly string LessThanOneHour = $@"(?<lth>(a\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\s+(minutes?|mins?))|{DeltaMinuteNumRegex}(\s+(minutes?|mins?)))";
+      public static readonly string LessThanOneHour = $@"(?<lth>(a\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\s+(minutes?|mins?)|(?=\s+past))|{DeltaMinuteNumRegex}(\s+(minutes?|mins?)|(?=\s+past)))";
       public static readonly string WrittenTimeRegex = $@"(?<writtentime>{HourNumRegex}\s+{MinuteNumRegex}(\s+(minutes?|mins?))?)";
       public static readonly string TimePrefix = $@"(?<prefix>{LessThanOneHour}\s+(past|to))";
       public static readonly string TimeSuffix = $@"(?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})";

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
@@ -486,7 +486,7 @@ public class EnglishDateTime {
 
     public static final String CommonDatePrefixRegex = "^[\\.]";
 
-    public static final String LessThanOneHour = "(?<lth>(a\\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\\s+(minutes?|mins?))|{DeltaMinuteNumRegex}(\\s+(minutes?|mins?)))"
+    public static final String LessThanOneHour = "(?<lth>(a\\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\\s+(minutes?|mins?)|(?=\\s+past))|{DeltaMinuteNumRegex}(\\s+(minutes?|mins?)|(?=\\s+past)))"
             .replace("{BaseDateTime.DeltaMinuteRegex}", BaseDateTime.DeltaMinuteRegex)
             .replace("{DeltaMinuteNumRegex}", DeltaMinuteNumRegex);
 

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -150,7 +150,7 @@ export namespace EnglishDateTime {
     export const LunchRegex = `\\blunchtime\\b`;
     export const NightRegex = `\\b(mid)?night\\b`;
     export const CommonDatePrefixRegex = `^[\\.]`;
-    export const LessThanOneHour = `(?<lth>(a\\s+)?quarter|three quarter(s)?|half( an hour)?|${BaseDateTime.DeltaMinuteRegex}(\\s+(minutes?|mins?))|${DeltaMinuteNumRegex}(\\s+(minutes?|mins?)))`;
+    export const LessThanOneHour = `(?<lth>(a\\s+)?quarter|three quarter(s)?|half( an hour)?|${BaseDateTime.DeltaMinuteRegex}(\\s+(minutes?|mins?)|(?=\\s+past))|${DeltaMinuteNumRegex}(\\s+(minutes?|mins?)|(?=\\s+past)))`;
     export const WrittenTimeRegex = `(?<writtentime>${HourNumRegex}\\s+${MinuteNumRegex}(\\s+(minutes?|mins?))?)`;
     export const TimePrefix = `(?<prefix>${LessThanOneHour}\\s+(past|to))`;
     export const TimeSuffix = `(?<suffix>${AmRegex}|${PmRegex}|${OclockRegex})`;

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -362,7 +362,7 @@ NightRegex: !simpleRegex
 CommonDatePrefixRegex: !simpleRegex
   def: ^[\.]
 LessThanOneHour: !nestedRegex
-  def: (?<lth>(a\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\s+(minutes?|mins?))|{DeltaMinuteNumRegex}(\s+(minutes?|mins?)))
+  def: (?<lth>(a\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\s+(minutes?|mins?)|(?=\s+past))|{DeltaMinuteNumRegex}(\s+(minutes?|mins?)|(?=\s+past)))
   references: [ BaseDateTime.DeltaMinuteRegex, DeltaMinuteNumRegex ]
 WrittenTimeRegex: !nestedRegex
   def: (?<writtentime>{HourNumRegex}\s+{MinuteNumRegex}(\s+(minutes?|mins?))?)

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'datatypes_timex_expression_genesys'
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'recognizers-text-choice-genesys'
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -153,7 +153,7 @@ class EnglishDateTime:
     LunchRegex = f'\\blunchtime\\b'
     NightRegex = f'\\b(mid)?night\\b'
     CommonDatePrefixRegex = f'^[\\.]'
-    LessThanOneHour = f'(?<lth>(a\\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\\s+(minutes?|mins?))|{DeltaMinuteNumRegex}(\\s+(minutes?|mins?)))'
+    LessThanOneHour = f'(?<lth>(a\\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\\s+(minutes?|mins?)|(?=\\s+past))|{DeltaMinuteNumRegex}(\\s+(minutes?|mins?)|(?=\\s+past)))'
     WrittenTimeRegex = f'(?<writtentime>{HourNumRegex}\\s+{MinuteNumRegex}(\\s+(minutes?|mins?))?)'
     TimePrefix = f'(?<prefix>{LessThanOneHour}\\s+(past|to))'
     TimeSuffix = f'(?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})'

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = 'recognizers-text-date-time-genesys'
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-with-unit-genesys"
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-genesys"
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 
 REQUIRES = ['recognizers-text-genesys', 'regex']
 

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-sequence-genesys"
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,14 +11,14 @@ def read(fname):
 
 NAME = 'recognizers-text-suite-genesys'
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.32',
-    'recognizers-text-number-genesys==1.0.32',
-    'recognizers-text-number-with-unit-genesys==1.0.32',
-    'recognizers-text-date-time-genesys==1.0.32',
-    'recognizers-text-sequence-genesys==1.0.32',
-    'recognizers-text-choice-genesys==1.0.32'
+    'recognizers-text-genesys==1.0.33',
+    'recognizers-text-number-genesys==1.0.33',
+    'recognizers-text-number-with-unit-genesys==1.0.33',
+    'recognizers-text-date-time-genesys==1.0.33',
+    'recognizers-text-sequence-genesys==1.0.33',
+    'recognizers-text-choice-genesys==1.0.33'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 

--- a/Specs/DateTime/English/TimeExtractor.json
+++ b/Specs/DateTime/English/TimeExtractor.json
@@ -308,6 +308,50 @@
     ]
   },
   {
+    "Input": "I made this purchase at 10 past 9",
+    "Results": [
+      {
+        "Text": "10 past 9",
+        "Type": "time",
+        "Start": 24,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "It's 15 past seven o'clock",
+    "Results": [
+      {
+        "Text": "15 past seven o'clock",
+        "Type": "time",
+        "Start": 5,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "I made this purchase at ten past 9 in the evening",
+    "Results": [
+      {
+        "Text": "ten past 9 in the evening",
+        "Type": "time",
+        "Start": 24,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "It's fifteen past eight in the morning",
+    "Results": [
+      {
+        "Text": "fifteen past eight in the morning",
+        "Type": "time",
+        "Start": 5,
+        "Length": 33
+      }
+    ]
+  },
+  {
     "Input": "I'll be back in the afternoon at 7",
     "Results": [
       {

--- a/Specs/DateTime/English/TimeParser.json
+++ b/Specs/DateTime/English/TimeParser.json
@@ -660,6 +660,86 @@
     ]
   },
   {
+    "Input": "I made this purchase at 10 past 9",
+    "Results": [
+      {
+        "Text": "10 past 9",
+        "Type": "time",
+        "Value": {
+          "Timex": "T09:10",
+          "FutureResolution": {
+            "time": "09:10:00"
+          },
+          "PastResolution": {
+            "time": "09:10:00"
+          }
+        },
+        "Start": 24,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "It's 15 past seven o'clock",
+    "Results": [
+      {
+        "Text": "15 past seven o'clock",
+        "Type": "time",
+        "Value": {
+          "Timex": "T07:15",
+          "FutureResolution": {
+            "time": "07:15:00"
+          },
+          "PastResolution": {
+            "time": "07:15:00"
+          }
+        },
+        "Start": 5,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "I made this purchase at ten past 9 in the evening",
+    "Results": [
+      {
+        "Text": "ten past 9 in the evening",
+        "Type": "time",
+        "Value": {
+          "Timex": "T21:10",
+          "FutureResolution": {
+            "time": "21:10:00"
+          },
+          "PastResolution": {
+            "time": "21:10:00"
+          }
+        },
+        "Start": 24,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "It's fifteen past eight in the morning",
+    "Results": [
+      {
+        "Text": "fifteen past eight in the morning",
+        "Type": "time",
+        "Value": {
+          "Timex": "T08:15",
+          "FutureResolution": {
+            "time": "08:15:00"
+          },
+          "PastResolution": {
+            "time": "08:15:00"
+          }
+        },
+        "Start": 5,
+        "Length": 33
+      }
+    ]
+  },
+  {
     "Input": "I'll be back in the afternoon at 7",
     "Results": [
       {


### PR DESCRIPTION
This is a fix for the "[minutes] past [hour]" time format such as "10 past 3" and "ten past three".