### PR TITLE
[NLU-3224] V3 Entity Improvement: DE-DE time: 5 minuten vor 4

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string NightRegex = @"\b(mitternacht|(nachts?|primetime|abends?))\b";
       public const string AmPmPrefixRegex = @"\b((((um|gegen)\s*)?(?<suffix>(((?<am>am morgen)|((früh|spät)\s*)?morgens|früh|(vor|nach)mittags?)|(?<pm>((früh|spät)\s*)?(nachmittags?|abends?)|mitternachts?))|(in der\s*)?(?<pm>nachts?)))\s*(um|gegen|von)\s*)";
       public const string CommonDatePrefixRegex = @"^[\.]";
-      public static readonly string LessThanOneHour = $@"\b(?<lth>(ein(er?)?\s+)?((drei)?viertel|halb(en?)?)(\s*stunden?)?)|{BaseDateTime.DeltaMinuteRegex}(\s+(min(uten?)?)|(?=\s+nach))|{DeltaMinuteNumRegex}(\s+(min(uten?)?)|(?=\s+nach))";
+      public static readonly string LessThanOneHour = $@"\b(?<lth>(ein(er?)?\s+)?((drei)?viertel|halb(en?)?)(\s*stunden?)?)|{BaseDateTime.DeltaMinuteRegex}(\s+(min(uten?)?)|(?=\s+(nach|vor)))|{DeltaMinuteNumRegex}(\s+(min(uten?)?)|(?=\s+(nach|vor)))";
       public static readonly string WrittenTimeRegex = $@"(um\s*)?(?<writtentime>{HourNumRegex}(\s*{OclockRegex}\s*)({MinuteNumRegex}|{MinuteNumRegex}und(?<tens>zwanzig|dreißig|vierzig|fünfzig)))";
       public static readonly string TimePrefix = $@"(?<prefix>({LessThanOneHour})(\s*(vor(\W)?|nach(\W)?))?)";
       public static readonly string TimeSuffix = $@"(?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
@@ -105,13 +105,13 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                     minStr = match.Groups["deltaminnum"].Value;
                     deltaMin = Numbers[minStr];
                 }
-            }
 
-            // @TODO move hardcoded values to resources file
+                // @TODO move hardcoded values to resources file
 
-            if (trimmedPrefix.EndsWith("zum", StringComparison.Ordinal))
-            {
-                deltaMin = -deltaMin;
+                if (trimmedPrefix.EndsWith("vor", StringComparison.Ordinal))
+                {
+                    deltaMin = -deltaMin;
+                }
             }
 
             min += deltaMin;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/german/parsers/GermanTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/german/parsers/GermanTimeParserConfiguration.java
@@ -109,10 +109,9 @@ public class GermanTimeParserConfiguration extends BaseOptionsConfiguration impl
                 minStr = match.get().getGroup("deltaminnum").value;
                 deltaMin = numbers.getOrDefault(minStr, 0);
             }
-        }
-
-        if (trimmedPrefix.endsWith("zum")) {
-            deltaMin = -deltaMin;
+            if (trimmedPrefix.endsWith("vor")) {
+                deltaMin = -deltaMin;
+            }
         }
 
         min += deltaMin;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/GermanDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/GermanDateTime.java
@@ -348,7 +348,7 @@ public class GermanDateTime {
 
     public static final String CommonDatePrefixRegex = "^[\\.]";
 
-    public static final String LessThanOneHour = "\\b(?<lth>(ein(er?)?\\s+)?((drei)?viertel|halb(en?)?)(\\s*stunden?)?)|{BaseDateTime.DeltaMinuteRegex}(\\s+(min(uten?)?)|(?=\\s+nach))|{DeltaMinuteNumRegex}(\\s+(min(uten?)?)|(?=\\s+nach))"
+    public static final String LessThanOneHour = "\\b(?<lth>(ein(er?)?\\s+)?((drei)?viertel|halb(en?)?)(\\s*stunden?)?)|{BaseDateTime.DeltaMinuteRegex}(\\s+(min(uten?)?)|(?=\\s+(nach|vor)))|{DeltaMinuteNumRegex}(\\s+(min(uten?)?)|(?=\\s+(nach|vor)))"
             .replace("{BaseDateTime.DeltaMinuteRegex}", BaseDateTime.DeltaMinuteRegex)
             .replace("{DeltaMinuteNumRegex}", DeltaMinuteNumRegex);
 

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -271,7 +271,7 @@ AmPmPrefixRegex: !simpleRegex
 CommonDatePrefixRegex: !simpleRegex
   def: ^[\.]
 LessThanOneHour: !nestedRegex
-  def: \b(?<lth>(ein(er?)?\s+)?((drei)?viertel|halb(en?)?)(\s*stunden?)?)|{BaseDateTime.DeltaMinuteRegex}(\s+(min(uten?)?)|(?=\s+nach))|{DeltaMinuteNumRegex}(\s+(min(uten?)?)|(?=\s+nach))
+  def: \b(?<lth>(ein(er?)?\s+)?((drei)?viertel|halb(en?)?)(\s*stunden?)?)|{BaseDateTime.DeltaMinuteRegex}(\s+(min(uten?)?)|(?=\s+(nach|vor)))|{DeltaMinuteNumRegex}(\s+(min(uten?)?)|(?=\s+(nach|vor)))
   references: [ BaseDateTime.DeltaMinuteRegex, DeltaMinuteNumRegex ]
 WrittenTimeRegex: !nestedRegex
   def: (um\s*)?(?<writtentime>{HourNumRegex}(\s*{OclockRegex}\s*)({MinuteNumRegex}|{MinuteNumRegex}und(?<tens>zwanzig|dreißig|vierzig|fünfzig)))

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'datatypes_timex_expression_genesys'
 
-VERSION = '1.0.35a0'
+VERSION = '1.0.36'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'recognizers-text-choice-genesys'
 
-VERSION = '1.0.35a0'
+VERSION = '1.0.36'
 
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/german/time_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/german/time_parser_config.py
@@ -91,8 +91,8 @@ class GermanTimeParserConfiguration(TimeParserConfiguration):
                         match, 'deltaminnum').lower()
                     delta_min = self.numbers.get(min_str)
 
-        if trimmed_prefix.startswith('zum'):
-            delta_min = delta_min * -1
+            if trimmed_prefix.endswith('vor'):
+                delta_min = delta_min * -1
 
         adjust.minute += delta_min
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/german_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/german_date_time.py
@@ -118,7 +118,7 @@ class GermanDateTime:
     NightRegex = f'\\b(mitternacht|(nachts?|primetime|abends?))\\b'
     AmPmPrefixRegex = f'\\b((((um|gegen)\\s*)?(?<suffix>(((?<am>am morgen)|((früh|spät)\\s*)?morgens|früh|(vor|nach)mittags?)|(?<pm>((früh|spät)\\s*)?(nachmittags?|abends?)|mitternachts?))|(in der\\s*)?(?<pm>nachts?)))\\s*(um|gegen|von)\\s*)'
     CommonDatePrefixRegex = f'^[\\.]'
-    LessThanOneHour = f'\\b(?<lth>(ein(er?)?\\s+)?((drei)?viertel|halb(en?)?)(\\s*stunden?)?)|{BaseDateTime.DeltaMinuteRegex}(\\s+(min(uten?)?)|(?=\\s+nach))|{DeltaMinuteNumRegex}(\\s+(min(uten?)?)|(?=\\s+nach))'
+    LessThanOneHour = f'\\b(?<lth>(ein(er?)?\\s+)?((drei)?viertel|halb(en?)?)(\\s*stunden?)?)|{BaseDateTime.DeltaMinuteRegex}(\\s+(min(uten?)?)|(?=\\s+(nach|vor)))|{DeltaMinuteNumRegex}(\\s+(min(uten?)?)|(?=\\s+(nach|vor)))'
     WrittenTimeRegex = f'(um\\s*)?(?<writtentime>{HourNumRegex}(\\s*{OclockRegex}\\s*)({MinuteNumRegex}|{MinuteNumRegex}und(?<tens>zwanzig|dreißig|vierzig|fünfzig)))'
     TimePrefix = f'(?<prefix>({LessThanOneHour})(\\s*(vor(\\W)?|nach(\\W)?))?)'
     TimeSuffix = f'(?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})'

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = 'recognizers-text-date-time-genesys'
 
-VERSION = '1.0.35a0'
+VERSION = '1.0.36'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-with-unit-genesys"
 
-VERSION = '1.0.35a0'
+VERSION = '1.0.36'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-number-genesys"
 
-VERSION = '1.0.35a0'
+VERSION = '1.0.36'
 
 REQUIRES = ['recognizers-text-genesys', 'regex']
 

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 NAME = "recognizers-text-sequence-genesys"
 
-VERSION = '1.0.35a0'
+VERSION = '1.0.36'
 
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,14 +11,14 @@ def read(fname):
 
 NAME = 'recognizers-text-suite-genesys'
 
-VERSION = '1.0.35a0'
+VERSION = '1.0.36'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.35a0',
-    'recognizers-text-number-genesys==1.0.35a0',
-    'recognizers-text-number-with-unit-genesys==1.0.35a0',
-    'recognizers-text-date-time-genesys==1.0.35a0',
-    'recognizers-text-sequence-genesys==1.0.35a0',
-    'recognizers-text-choice-genesys==1.0.35a0'
+    'recognizers-text-genesys==1.0.36',
+    'recognizers-text-number-genesys==1.0.36',
+    'recognizers-text-number-with-unit-genesys==1.0.36',
+    'recognizers-text-date-time-genesys==1.0.36',
+    'recognizers-text-sequence-genesys==1.0.36',
+    'recognizers-text-choice-genesys==1.0.36'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
 
-VERSION = '1.0.35a0'
+VERSION = '1.0.36'
 
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 

--- a/Specs/DateTime/German/TimeExtractor.json
+++ b/Specs/DateTime/German/TimeExtractor.json
@@ -228,6 +228,78 @@
     ]
   },
   {
+    "Input": "Es ist 5 vor 3",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "5 vor 3",
+        "Type": "time",
+        "Start": 7,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Es ist 5 minuten vor 4",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "5 minuten vor 4",
+        "Type": "time",
+        "Start": 7,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "Es ist 5 min vor vier",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "5 min vor vier",
+        "Type": "time",
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Es ist fünf minuten vor 8",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "fünf minuten vor 8",
+        "Type": "time",
+        "Start": 7,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Es ist fünf vor vier",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "fünf vor vier",
+        "Type": "time",
+        "Start": 7,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Es ist fünf minuten vor vier",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "fünf minuten vor vier",
+        "Type": "time",
+        "Start": 7,
+        "Length": 21
+      }
+    ]
+  },
+  {
     "Input": "Es ist viertel nach acht",
     "NotSupported": "javascript",
     "Results": [

--- a/Specs/DateTime/German/TimeParser.json
+++ b/Specs/DateTime/German/TimeParser.json
@@ -210,6 +210,132 @@
     ]
   },
   {
+    "Input": "Es ist 5 vor 3 Vormittags",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "5 vor 3 vormittags",
+        "Type": "time",
+        "Value": {
+          "Timex": "T02:55",
+          "FutureResolution": {
+            "time": "02:55:00"
+          },
+          "PastResolution": {
+            "time": "02:55:00"
+          }
+        },
+        "Start": 7,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Es ist 5 minuten vor 4 Nachmittag",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "5 minuten vor 4 nachmittag",
+        "Type": "time",
+        "Value": {
+          "Timex": "T15:55",
+          "FutureResolution": {
+            "time": "15:55:00"
+          },
+          "PastResolution": {
+            "time": "15:55:00"
+          }
+        },
+        "Start": 7,
+        "Length": 26
+      }
+    ]
+  },
+  {
+    "Input": "Es ist 5 min vor vier vormittags",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "5 min vor vier vormittags",
+        "Type": "time",
+        "Value": {
+          "Timex": "T03:55",
+          "FutureResolution": {
+            "time": "03:55:00"
+          },
+          "PastResolution": {
+            "time": "03:55:00"
+          }
+        },
+        "Start": 7,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "Es ist fünf minuten vor 8 Nachmittag",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "fünf minuten vor 8 nachmittag",
+        "Type": "time",
+        "Value": {
+          "Timex": "T19:55",
+          "FutureResolution": {
+            "time": "19:55:00"
+          },
+          "PastResolution": {
+            "time": "19:55:00"
+          }
+        },
+        "Start": 7,
+        "Length": 29
+      }
+    ]
+  },
+  {
+    "Input": "Es ist fünf vor zehn Vormittags",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "fünf vor zehn vormittags",
+        "Type": "time",
+        "Value": {
+          "Timex": "T09:55",
+          "FutureResolution": {
+            "time": "09:55:00"
+          },
+          "PastResolution": {
+            "time": "09:55:00"
+          }
+        },
+        "Start": 7,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "Es ist fünf minuten vor vier nachmittag",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "fünf minuten vor vier nachmittag",
+        "Type": "time",
+        "Value": {
+          "Timex": "T15:55",
+          "FutureResolution": {
+            "time": "15:55:00"
+          },
+          "PastResolution": {
+            "time": "15:55:00"
+          }
+        },
+        "Start": 7,
+        "Length": 32
+      }
+    ]
+  },
+  {
     "Input": "Ich habe den Alarm auf 8:40 eingestellt",
     "NotSupported": "javascript",
     "Results": [


### PR DESCRIPTION
Adding support for German time expressions like "5 minuten vor 4" and "fünf vor vier".

For reference:
- [Time Expressions in German](http://www.dartmouth.edu/~deutsch/Grammatik/Zeit/Time.html)
- [German Time Phrases & Expressions](https://zinglanguages.com/knowledgehub/german-time-phrases-expressions/)