### PR TITLE
[NLU-3681] Fix for infinite loop issue in BaseDateParser

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.56a0'
+VERSION = '1.0.56'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.55'
+VERSION = '1.0.56a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.55'
+VERSION = '1.0.56a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.56a0'
+VERSION = '1.0.56'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/CJK/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/CJK/base_date.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from abc import abstractmethod
 
 from datedelta import datedelta
+from dateutil.relativedelta import relativedelta
 
 from ..utilities import Token
 from typing import List, Pattern, Dict, Match
@@ -778,16 +779,14 @@ class BaseCJKDateParser(DateTimeParser):
             # and decrease the pivotDate month by month to the latest previousDate. Notice: if the "day" is larger
             # than 28, some months should be ignored in the increase or decrease procedure.
 
-            pivot_date = datetime(year, month, day)
             days_in_month = calendar.monthrange(year, month)[1]
             if days_in_month >= day:
                 pivot_date = DateUtils.safe_create_from_min_value(year, month, day)
             else:
                 # Add 1 month is enough, since 1, 3, 5, 7, 8, 10, 12 months has 31 days
-                pivot_date = pivot_date + datedelta(months=1)
-                pivot_date = DateUtils.safe_create_from_min_value(pivot_date.year, pivot_date.month, pivot_date.day)
+                pivot_date = DateUtils.safe_create_from_min_value(year, month + 1, day)
 
-            num_week_day_int = pivot_date.isoweekday()
+            num_week_day_int = pivot_date.isoweekday() % 7
             extracted_week_day_str = match.get_group(Date_Constants.WEEKDAY_GROUP_NAME)
             week_day = self.config.day_of_week[extracted_week_day_str]
 
@@ -802,10 +801,10 @@ class BaseCJKDateParser(DateTimeParser):
                     future_date = pivot_date
                     past_date = pivot_date
 
-                    while future_date.isoweekday() != week_day or future_date.day != day or future_date < reference:
+                    while future_date.isoweekday() % 7 != week_day or future_date.day != day or future_date < reference:
                         # Increase the futureDate month by month to find the expected date (the "day" is the weekday)
                         # and make sure the futureDate not less than the referenceDate.
-                        future_date += datedelta(months=1)
+                        future_date += relativedelta(months=1)
                         tmp_days_in_month = calendar.monthrange(future_date.year, future_date.month)[1]
                         if tmp_days_in_month >= day:
                             # For months like January 31, after add 1 month, February 31 won't be returned,
@@ -815,11 +814,11 @@ class BaseCJKDateParser(DateTimeParser):
 
                     result_value.future_value = future_date
 
-                    while past_date.isoweekday() != week_day or past_date.day != day or past_date > reference:
+                    while past_date.isoweekday() % 7 != week_day or past_date.day != day or past_date > reference:
                         # Decrease the pastDate month by month to find the expected date (the "day" is the weekday) and
                         # make sure the pastDate not larger than the referenceDate.
-                        past_date -= datedelta(months=1)
-                        tmp_days_in_month = calendar.monthrange(past_date.year, future_date.month)[1]
+                        past_date -= relativedelta(months=1)
+                        tmp_days_in_month = calendar.monthrange(past_date.year, past_date.month)[1]
                         if tmp_days_in_month >= day:
                             # For months like March 31, after minus 1 month, February 31
                             # won't be returned, so the day should be revised ASAP.

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from typing import List, Optional, Pattern, Dict, Match
 from datetime import datetime, timedelta
 
+from dateutil.relativedelta import relativedelta
 from recognizers_date_time.date_time.abstract_year_extractor import AbstractYearExtractor
 from datedelta import datedelta
 from recognizers_text.extractor import ExtractResult
@@ -1243,10 +1244,9 @@ class BaseDateParser(DateTimeParser):
                 pivot_date = DateUtils.safe_create_from_min_value(year, month, day)
             else:
                 # Add 1 month is enough, since 1, 3, 5, 7, 8, 10, 12 months has 31 days
-                pivot_date = datetime(year, month, day) + datedelta(months=1)
-                pivot_date = DateUtils.safe_create_from_min_value(pivot_date.year, pivot_date.month, pivot_date.day)
+                pivot_date = DateUtils.safe_create_from_min_value(year, month + 1, day)
 
-            num_week_day_int = pivot_date.isoweekday()
+            num_week_day_int = pivot_date.isoweekday() % 7
             extracted_week_day_str = match.group(Constants.WEEKDAY_GROUP_NAME)
             week_day = self.config.day_of_week.get(extracted_week_day_str)
 
@@ -1260,10 +1260,10 @@ class BaseDateParser(DateTimeParser):
                     future_date = pivot_date
                     past_date = pivot_date
 
-                    while future_date.isoweekday() != week_day or future_date.day != day or future_date < reference:
+                    while future_date.isoweekday() % 7 != week_day or future_date.day != day or future_date < reference:
                         # Increase the futureDate month by month to find the expected date (the "day" is the weekday) and
                         # make sure the futureDate not less than the referenceDate.
-                        future_date += datedelta(months=1)
+                        future_date += relativedelta(months=1)
                         tmp_days_in_month = calendar.monthrange(future_date.year, future_date.month)[1]
                         if tmp_days_in_month >= day:
                             # For months like January 31, after add 1 month, February 31 won't be returned, so the day should be revised ASAP.
@@ -1271,11 +1271,11 @@ class BaseDateParser(DateTimeParser):
 
                     result.future_value = future_date
 
-                    while past_date.isoweekday() != week_day or past_date.day != day or past_date > reference:
+                    while past_date.isoweekday() % 7 != week_day or past_date.day != day or past_date > reference:
                         # Decrease the pastDate month by month to find the expected date (the "day" is the weekday) and
                         # make sure the pastDate not larger than the referenceDate.
-                        past_date += datedelta(months=-1)
-                        tmp_days_in_month = calendar.monthrange(past_date.year, future_date.month)[1]
+                        past_date -= relativedelta(months=1)
+                        tmp_days_in_month = calendar.monthrange(past_date.year, past_date.month)[1]
                         if tmp_days_in_month >= day:
                             # For months like March 31, after minus 1 month, February 31 won't be returned, so the day should be revised ASAP.
                             past_date = DateUtils.safe_create_from_value(DateUtils.min_value, past_date.year, past_date.month, day)

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.56a0'
+VERSION = '1.0.56'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 NAME = 'recognizers-text-date-time-genesys'
 VERSION = '1.0.55'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
-            'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta']
+            'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 
 setup(
     name=NAME,

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.55'
+VERSION = '1.0.56a0'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.55"
+VERSION = "1.0.56a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.56a0"
+VERSION = "1.0.56"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.56a0"
+VERSION = "1.0.56"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.55"
+VERSION = "1.0.56a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.55"
+VERSION = "1.0.56a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.56a0"
+VERSION = "1.0.56"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.55'
+VERSION = '1.0.56a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.55',
-    'recognizers-text-number-genesys==1.0.55',
-    'recognizers-text-number-with-unit-genesys==1.0.55',
-    'recognizers-text-date-time-genesys==1.0.55',
-    'recognizers-text-sequence-genesys==1.0.55',
-    'recognizers-text-choice-genesys==1.0.55',
-    'datatypes_timex_expression_genesys==1.0.55'
+    'recognizers-text-genesys==1.0.56a0',
+    'recognizers-text-number-genesys==1.0.56a0',
+    'recognizers-text-number-with-unit-genesys==1.0.56a0',
+    'recognizers-text-date-time-genesys==1.0.56a0',
+    'recognizers-text-sequence-genesys==1.0.56a0',
+    'recognizers-text-choice-genesys==1.0.56a0',
+    'datatypes_timex_expression_genesys==1.0.56a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.56a0'
+VERSION = '1.0.56'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.56a0',
-    'recognizers-text-number-genesys==1.0.56a0',
-    'recognizers-text-number-with-unit-genesys==1.0.56a0',
-    'recognizers-text-date-time-genesys==1.0.56a0',
-    'recognizers-text-sequence-genesys==1.0.56a0',
-    'recognizers-text-choice-genesys==1.0.56a0',
-    'datatypes_timex_expression_genesys==1.0.56a0'
+    'recognizers-text-genesys==1.0.56',
+    'recognizers-text-number-genesys==1.0.56',
+    'recognizers-text-number-with-unit-genesys==1.0.56',
+    'recognizers-text-date-time-genesys==1.0.56',
+    'recognizers-text-sequence-genesys==1.0.56',
+    'recognizers-text-choice-genesys==1.0.56',
+    'datatypes_timex_expression_genesys==1.0.56'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.56a0"
+VERSION = "1.0.56"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.55"
+VERSION = "1.0.56a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,4 +1,5 @@
 datedelta
+python-dateutil
 pre-commit==1.16.1
 autopep8
 flake8

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -8488,7 +8488,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": [
       {
         "Text": "maandag 21",
@@ -8517,7 +8517,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": [
       {
         "Text": "zondag 31",
@@ -8546,7 +8546,7 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": [
       {
         "Text": "vrijdag 31",
@@ -8564,6 +8564,35 @@
               "timex": "XXXX-WXX-5",
               "type": "date",
               "value": "2019-05-31"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Heb je een arrangement op zaterdag 30!",
+    "Context": {
+      "ReferenceDateTime": "2023-07-05T12:00:00"
+    },
+    "NotSupportedByDesign": "javascript,java",
+    "Results": [
+      {
+        "Text": "zaterdag 30",
+        "Start": 26,
+        "End": 36,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2022-07-30"
+            },
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2023-09-30"
             }
           ]
         }

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -10108,7 +10108,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupportedByDesign": "javascript, java, python",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "sunday 31",
@@ -10137,7 +10137,7 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupportedByDesign": "javascript, java, python",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "friday 31",
@@ -10155,6 +10155,35 @@
               "timex": "XXXX-WXX-5",
               "type": "date",
               "value": "2019-05-31"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Do you have any arrangement on Saturday 30?",
+    "Context": {
+      "ReferenceDateTime": "2023-07-05T12:00:00"
+    },
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "saturday 30",
+        "Start": 31,
+        "End": 41,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2022-07-30"
+            },
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2023-09-30"
             }
           ]
         }

--- a/Specs/DateTime/Hindi/DateTimeModel.json
+++ b/Specs/DateTime/Hindi/DateTimeModel.json
@@ -9675,7 +9675,7 @@
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
     "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": [
       {
         "Text": "21 सोमवार",
@@ -9704,7 +9704,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-21T12:00:00"
     },
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": [
       {
         "Text": "21 सोमवार",
@@ -9729,7 +9729,7 @@
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
     "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": [
       {
         "Text": "रविवार 31",
@@ -9759,7 +9759,7 @@
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
     "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": [
       {
         "Text": "31 शुक्रवार",
@@ -9777,6 +9777,35 @@
               "timex": "XXXX-WXX-5",
               "type": "date",
               "value": "2019-05-31"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "क्या शनिवार 30 तारीख को कोई व्यवस्था है!",
+    "Context": {
+      "ReferenceDateTime": "2023-07-05T12:00:00"
+    },
+    "NotSupportedByDesign": "javascript,java",
+    "Results": [
+      {
+        "Text": "शनिवार 30",
+        "Start": 5,
+        "End": 14,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2022-07-30"
+            },
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2023-09-30"
             }
           ]
         }

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -11610,7 +11610,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "lunes 21",
@@ -11639,7 +11639,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-21T12:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "lunes 21",
@@ -11663,7 +11663,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "domingo 31",
@@ -11692,7 +11692,7 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "viernes 31",
@@ -11710,6 +11710,35 @@
               "timex": "XXXX-WXX-5",
               "type": "date",
               "value": "2019-05-31"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "¿Tienes algún arreglo para el sábado 30?",
+    "Context": {
+      "ReferenceDateTime": "2023-07-05T12:00:00"
+    },
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "sábado 30",
+        "Start": 30,
+        "End": 38,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2022-07-30"
+            },
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2023-09-30"
             }
           ]
         }


### PR DESCRIPTION
This is a fix for an issue found in the `BaseDateParser.parse_implicit_date` method.
Within the method there is a section responsible for parsing dates in the format of `<weekday> <day>` such as “Saturday 30”. It looks for past and future dates that correspond to the extracted weekday and day values, iterating through months starting with the current one.

The function relies on the **datedelta** library for date calculations. There's a bug (unexpected behaviour) in the datedelta library - in some cases it does not subtract the entire month. For example, when subtracting one month from the 30th of March, the library returns the 1st of March instead of the expected 28th of February. This causes an infinite loop as the month remains unchanged within the loop.

The pull request fixes the issue by replacing the **datedelta** library with the [python-dateutil](https://github.com/dateutil/dateutil) library which works as expected.
