### PR TITLE
[NLU-3753] Fix German Date <WeekDay><Day><Month>

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string WeekDayOfMonthRegex = $@"\b(?<wom>((an( dem)?|de[rs]|am)\s+)?(?<cardinal>erste[rns]?|1\.|zweite[rns]?|2\.|dritte[rns]?|3\.|vierte[rns]?|4\.|fünfte[rns]?|5\.|letzte[rmns]?)\s+{WeekDayRegex}\s+{MonthSuffixRegex})\b";
       public static readonly string RelativeWeekDayRegex = $@"\b({WrittenNumRegex}\s+{WeekDayRegex}e\s+(von\s+jetzt|später))\b";
       public static readonly string SpecialDate = $@"(?=\b(an( dem)?|am)\s+){DayRegex}\b";
-      public static readonly string DateExtractor1 = $@"\b(({WeekDayRegex})(\s+|\s*,\s*))?({DayRegex}\s*[/\\.,\- ]\s*{MonthRegex}(\s*[/\\.,\- ]\s*{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\s*[/\\.,\- ]\s*{DayRegex}\s*[/\\.,\- ]\s*{MonthRegex})\b";
+      public static readonly string DateExtractor1 = $@"\b(({WeekDayRegex})(\s+|\s*,\s*))?({DayRegex}\s*[/\\.,\- ]\s*({MonthNumRegex}|{MonthRegex})(\s*[/\\.,\- ]\s*{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\s*[/\\.,\- ]\s*{DayRegex}\s*[/\\.,\- ]\s*{MonthRegex})\b";
       public static readonly string DateExtractor2 = $@"\b({MonthRegex}\s*[/\\.,\- ]\s*{DayRegex}(?!\s*\-\s*\d{{2}}\b)(\s*[/\\.,\- ]\s*{DateYearRegex})?)\b";
       public static readonly string DateExtractor3 = $@"\b({DayRegex}{MonthRegex})";
       public static readonly string DateExtractor4 = $@"\b({DayRegex}\s*{MonthNumRegex}\s*{DateYearRegex})\b";

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/GermanDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/GermanDateTime.java
@@ -244,7 +244,7 @@ public class GermanDateTime {
     public static final String SpecialDate = "(?=\\b(an( dem)?|am)\\s+){DayRegex}\\b"
             .replace("{DayRegex}", DayRegex);
 
-    public static final String DateExtractor1 = "\\b(({WeekDayRegex})(\\s+|\\s*,\\s*))?({DayRegex}\\s*[/\\\\.,\\- ]\\s*{MonthRegex}(\\s*[/\\\\.,\\- ]\\s*{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\.,\\- ]\\s*{DayRegex}\\s*[/\\\\.,\\- ]\\s*{MonthRegex})\\b"
+    public static final String DateExtractor1 = "\\b(({WeekDayRegex})(\\s+|\\s*,\\s*))?({DayRegex}\\s*[/\\\\.,\\- ]\\s*({MonthNumRegex}|{MonthRegex})(\\s*[/\\\\.,\\- ]\\s*{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\.,\\- ]\\s*{DayRegex}\\s*[/\\\\.,\\- ]\\s*{MonthRegex})\\b"
             .replace("{WeekDayRegex}", WeekDayRegex)
             .replace("{MonthRegex}", MonthRegex)
             .replace("{DayRegex}", DayRegex)

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -199,8 +199,8 @@ SpecialDate: !nestedRegex
   def: (?=\b(an( dem)?|am)\s+){DayRegex}\b
   references: [ DayRegex ]
 DateExtractor1: !nestedRegex
-  def: \b(({WeekDayRegex})(\s+|\s*,\s*))?({DayRegex}\s*[/\\.,\- ]\s*{MonthRegex}(\s*[/\\.,\- ]\s*{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\s*[/\\.,\- ]\s*{DayRegex}\s*[/\\.,\- ]\s*{MonthRegex})\b
-  references: [ WeekDayRegex, MonthRegex, DayRegex, DateYearRegex, BaseDateTime.FourDigitYearRegex ]
+  def: \b(({WeekDayRegex})(\s+|\s*,\s*))?({DayRegex}\s*[/\\.,\- ]\s*({MonthNumRegex}|{MonthRegex})(\s*[/\\.,\- ]\s*{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\s*[/\\.,\- ]\s*{DayRegex}\s*[/\\.,\- ]\s*{MonthRegex})\b
+  references: [ WeekDayRegex, MonthRegex, MonthNumRegex, DayRegex, DateYearRegex, BaseDateTime.FourDigitYearRegex ]
 DateExtractor2: !nestedRegex
   def: \b({MonthRegex}\s*[/\\.,\- ]\s*{DayRegex}(?!\s*\-\s*\d{2}\b)(\s*[/\\.,\- ]\s*{DateYearRegex})?)\b
   references: [ WeekDayRegex, MonthRegex, DayRegex, DateYearRegex ]

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.62a0'
+VERSION = '1.0.62'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.61'
+VERSION = '1.0.62a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.61'
+VERSION = '1.0.62a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.62a0'
+VERSION = '1.0.62'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/german_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/german_date_time.py
@@ -91,7 +91,7 @@ class GermanDateTime:
     WeekDayOfMonthRegex = f'\\b(?<wom>((an( dem)?|de[rs]|am)\\s+)?(?<cardinal>erste[rns]?|1\\.|zweite[rns]?|2\\.|dritte[rns]?|3\\.|vierte[rns]?|4\\.|fünfte[rns]?|5\\.|letzte[rmns]?)\\s+{WeekDayRegex}\\s+{MonthSuffixRegex})\\b'
     RelativeWeekDayRegex = f'\\b({WrittenNumRegex}\\s+{WeekDayRegex}e\\s+(von\\s+jetzt|später))\\b'
     SpecialDate = f'(?=\\b(an( dem)?|am)\\s+){DayRegex}\\b'
-    DateExtractor1 = f'\\b(({WeekDayRegex})(\\s+|\\s*,\\s*))?({DayRegex}\\s*[/\\\\.,\\- ]\\s*{MonthRegex}(\\s*[/\\\\.,\\- ]\\s*{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\.,\\- ]\\s*{DayRegex}\\s*[/\\\\.,\\- ]\\s*{MonthRegex})\\b'
+    DateExtractor1 = f'\\b(({WeekDayRegex})(\\s+|\\s*,\\s*))?({DayRegex}\\s*[/\\\\.,\\- ]\\s*({MonthNumRegex}|{MonthRegex})(\\s*[/\\\\.,\\- ]\\s*{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\.,\\- ]\\s*{DayRegex}\\s*[/\\\\.,\\- ]\\s*{MonthRegex})\\b'
     DateExtractor2 = f'\\b({MonthRegex}\\s*[/\\\\.,\\- ]\\s*{DayRegex}(?!\\s*\\-\\s*\\d{{2}}\\b)(\\s*[/\\\\.,\\- ]\\s*{DateYearRegex})?)\\b'
     DateExtractor3 = f'\\b({DayRegex}{MonthRegex})'
     DateExtractor4 = f'\\b({DayRegex}\\s*{MonthNumRegex}\\s*{DateYearRegex})\\b'

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.61'
+VERSION = '1.0.62a0'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.62a0'
+VERSION = '1.0.62'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.62a0"
+VERSION = "1.0.62"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.61"
+VERSION = "1.0.62a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.61"
+VERSION = "1.0.62a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.62a0"
+VERSION = "1.0.62"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.62a0"
+VERSION = "1.0.62"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.61"
+VERSION = "1.0.62a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.62a0'
+VERSION = '1.0.62'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.62a0',
-    'recognizers-text-number-genesys==1.0.62a0',
-    'recognizers-text-number-with-unit-genesys==1.0.62a0',
-    'recognizers-text-date-time-genesys==1.0.62a0',
-    'recognizers-text-sequence-genesys==1.0.62a0',
-    'recognizers-text-choice-genesys==1.0.62a0',
-    'datatypes_timex_expression_genesys==1.0.62a0'
+    'recognizers-text-genesys==1.0.62',
+    'recognizers-text-number-genesys==1.0.62',
+    'recognizers-text-number-with-unit-genesys==1.0.62',
+    'recognizers-text-date-time-genesys==1.0.62',
+    'recognizers-text-sequence-genesys==1.0.62',
+    'recognizers-text-choice-genesys==1.0.62',
+    'datatypes_timex_expression_genesys==1.0.62'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.61'
+VERSION = '1.0.62a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.61',
-    'recognizers-text-number-genesys==1.0.61',
-    'recognizers-text-number-with-unit-genesys==1.0.61',
-    'recognizers-text-date-time-genesys==1.0.61',
-    'recognizers-text-sequence-genesys==1.0.61',
-    'recognizers-text-choice-genesys==1.0.61',
-    'datatypes_timex_expression_genesys==1.0.61'
+    'recognizers-text-genesys==1.0.62a0',
+    'recognizers-text-number-genesys==1.0.62a0',
+    'recognizers-text-number-with-unit-genesys==1.0.62a0',
+    'recognizers-text-date-time-genesys==1.0.62a0',
+    'recognizers-text-sequence-genesys==1.0.62a0',
+    'recognizers-text-choice-genesys==1.0.62a0',
+    'datatypes_timex_expression_genesys==1.0.62a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.62a0"
+VERSION = "1.0.62"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.61"
+VERSION = "1.0.62a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/DateTime/German/DateExtractor.json
+++ b/Specs/DateTime/German/DateExtractor.json
@@ -361,5 +361,16 @@
         "Length": 14
       }
     ]
+  },
+  {
+    "Input": "Um wie viel Uhr werde ich am Dienstag, den 15.6. den Doktor sehen?",
+    "Results": [
+      {
+        "Text": "dienstag, den 15.6",
+        "Type": "date",
+        "Start": 29,
+        "Length": 18
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -5687,5 +5687,33 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Um wie viel Uhr werde ich am Dienstag, den 15.6. den Doktor sehen?",
+    "Context": {
+      "ReferenceDateTime": "2023-08-02T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "dienstag, den 15.6",
+        "Start": 29,
+        "End": 46,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-06-15",
+              "type": "date",
+              "value": "2023-06-15"
+            },
+            {
+              "timex": "XXXX-06-15",
+              "type": "date",
+              "value": "2024-06-15"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixing an issue with resolving the German Date format `<WeekDay><Day><Month>`.

For example, "Dienstag, den 15.6." (Tuesday,  15/6) is being resolved as 2023-08-15 instead of the expected [2023-06-15, 2024-06-15].

It looks like the issue is that the `DateExtractor1` regex is missing a capturing group for the numeric month.
As a result, "Dienstag, den 15" (Tuesday, the 15th) is being resolved as 2023-08-15 because 2023-08-15 falls on a Tuesday.
This result takes precedence over "15.6" because it appears earlier in the text.

The issue is fixed by including the `MonthNumRegex` capturing group in the `DateExtractor1` regex.