### PR TITLE
[NLU-3937] ca-ES "mig" not recognized as part of numeral

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.88a1'
+VERSION = '1.0.88a2'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.88a2'
+VERSION = '1.0.88a3'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.88a0'
+VERSION = '1.0.88a1'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.87'
+VERSION = '1.0.88a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.88a3'
+VERSION = '1.0.88'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.88a3'
+VERSION = '1.0.88'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.88a1'
+VERSION = '1.0.88a2'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.88a2'
+VERSION = '1.0.88a3'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.88a0'
+VERSION = '1.0.88a1'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.87'
+VERSION = '1.0.88a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.88a1'
+VERSION = '1.0.88a2'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.88a2'
+VERSION = '1.0.88a3'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.88a3'
+VERSION = '1.0.88'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.87'
+VERSION = '1.0.88a0'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.88a0'
+VERSION = '1.0.88a1'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.88a1"
+VERSION = "1.0.88a2"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.88a2"
+VERSION = "1.0.88a3"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.88a3"
+VERSION = "1.0.88"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.88a0"
+VERSION = "1.0.88a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.87"
+VERSION = "1.0.88a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/recognizers_number/number/catalan/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/catalan/extractors.py
@@ -158,8 +158,7 @@ class CatalanDoubleExtractor(BaseNumberExtractor):
 
 class CatalanFractionExtractor(BaseNumberExtractor):
     @property
-    def regexes(self) -> List[
-            NamedTuple('re_val', [('re', Pattern), ('val', str)])]:
+    def regexes(self) -> List[NamedTuple('re_val', [('re', Pattern), ('val', str)])]:
         return self.__regexes
 
     @property
@@ -167,7 +166,31 @@ class CatalanFractionExtractor(BaseNumberExtractor):
         return Constants.SYS_NUM_FRACTION
 
     def __init__(self, mode):
-        self.__regexes = []
+        self.__regexes = [
+            ReVal(
+                re=RegExpUtility.get_safe_reg_exp(
+                    CatalanNumeric.FractionNotationWithSpacesRegex),
+                val='FracNum'),
+            ReVal(
+                re=RegExpUtility.get_safe_reg_exp(
+                    CatalanNumeric.FractionNotationRegex),
+                val='FracNum'),
+            ReVal(
+                re=RegExpUtility.get_safe_reg_exp(
+                    CatalanNumeric.FractionNounRegex),
+                val=f'Frac{CatalanNumeric.LangMarker}'),
+            ReVal(
+                re=RegExpUtility.get_safe_reg_exp(
+                    CatalanNumeric.FractionNounWithArticleRegex),
+                val=f'Frac{CatalanNumeric.LangMarker}')
+        ]
+
+        if mode != NumberMode.Unit:
+            self.__regexes.append(
+                ReVal(
+                    re=RegExpUtility.get_safe_reg_exp(
+                        CatalanNumeric.FractionPrepositionRegex),
+                    val=f'Frac{CatalanNumeric.LangMarker}'))
 
 
 class CatalanOrdinalExtractor(BaseNumberExtractor):

--- a/Python/libraries/recognizers-number/recognizers_number/number/catalan/parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/catalan/parsers.py
@@ -130,7 +130,7 @@ class CatalanNumberParserConfiguration(BaseNumberParserConfiguration):
         # e.g. 'dos i mig' ('two and a half') where the numerator is omitted in Catalan.
         # It works by inserting the numerator 'un' ('a') in the list frac_words
         # so that the pattern is correctly processed.
-        if len(frac_words) > 2:
+        if len(frac_words) >= 2:
             if frac_words[len(frac_words) - 1] in CatalanNumeric.OneHalfTokens[1:] and \
                     frac_words[len(frac_words) - 2] == CatalanNumeric.WordSeparatorToken:
                 frac_words.insert(len(frac_words) - 1, CatalanNumeric.OneHalfTokens[0])

--- a/Python/libraries/recognizers-number/recognizers_number/number/catalan/parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/catalan/parsers.py
@@ -131,9 +131,12 @@ class CatalanNumberParserConfiguration(BaseNumberParserConfiguration):
         # It works by inserting the numerator 'un' ('a') in the list frac_words
         # so that the pattern is correctly processed.
         if len(frac_words) >= 2:
-            if frac_words[len(frac_words) - 1] in CatalanNumeric.OneHalfTokens[1:] and \
-                    frac_words[len(frac_words) - 2] == CatalanNumeric.WordSeparatorToken:
-                frac_words.insert(len(frac_words) - 1, CatalanNumeric.OneHalfTokens[0])
+            if frac_words[-1] in CatalanNumeric.FractionalTokens[1:] and \
+                    frac_words[-2] == CatalanNumeric.WordSeparatorToken:
+                frac_words.insert(-1, CatalanNumeric.FractionWithoutNumeratorToken)
+            elif frac_words[-1] in CatalanNumeric.WrittenFractionSeparatorTexts and \
+                frac_words[-2] in CatalanNumeric.FractionalTokens[1:]:
+                    frac_words.pop(-1)
         return frac_words
 
     def resolve_composite_number(self, number_str: str) -> int:

--- a/Python/libraries/recognizers-number/recognizers_number/number/catalan/parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/catalan/parsers.py
@@ -134,10 +134,6 @@ class CatalanNumberParserConfiguration(BaseNumberParserConfiguration):
             if frac_words[len(frac_words) - 1] in CatalanNumeric.OneHalfTokens[1:] and \
                     frac_words[len(frac_words) - 2] == CatalanNumeric.WordSeparatorToken:
                 frac_words.insert(len(frac_words) - 1, CatalanNumeric.OneHalfTokens[0])
-            elif frac_words[len(frac_words) - 1] in CatalanNumeric.CardinalNumberMap:
-                frac_words[len(frac_words) - 1], frac_words[len(frac_words) - 2] = (frac_words[len(frac_words) - 2],
-                                                                                    frac_words[len(frac_words) - 1])
-                frac_words.insert(len(frac_words) - 1, CatalanNumeric.OneHalfTokens[0])
         return frac_words
 
     def resolve_composite_number(self, number_str: str) -> int:

--- a/Python/libraries/recognizers-number/recognizers_number/resources/catalan_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/catalan_numeric.py
@@ -7,7 +7,7 @@ class CatalanNumeric:
     CompoundNumberLanguage = False
     MultiDecimalSeparatorCulture = True
     NonStandardSeparatorVariants = []
-    RoundNumberIntegerRegex = f'((?:cents|milers|milions|milió|mil milions|bilió)s?|mil)'
+    RoundNumberIntegerRegex = f'((?:cent|miler|milion|milió|mil milions|bilió)s?|mil)'
     ZeroToNineIntegerRegex = f'(?:tres|set|vuit|quatre|cinc|zero|nou|un|dos|sis)'
     TwoToNineIntegerRegex = f'(?:tres|set|vuit|quatre|cinc|nou|dos|sis)'
     NegativeNumberTermsRegex = f'(?<negTerm>(menys|negatiu)\\s+)'
@@ -42,7 +42,7 @@ class CatalanNumeric:
     FractionNotationWithSpacesRegex = f'(((?<=\\W|^)-\\s*)|(?<=\\b))\\d+\\s+\\d+[/]\\d+(?=(\\b[^/]|$))'
     FractionNotationRegex = f'{BaseNumbers.FractionNotationRegex}'
     FractionMultiplierRegex = f'(?<fracMultiplier>(\\s+(i|un)\\s+)(i|un(a)?|dues|{TwoToNineIntegerRegex}\\s+)?(mig|quarts?|terç|cinquè|sisè|setena|vuitè|vuitena|novè|desè)s?(\\s+(de|d\'))?)'
-    RoundMultiplierWithFraction = f'(?<=(?<!{RoundNumberIntegerRegex}){FractionMultiplierRegex}\\s+)?(?<multiplier>(?:mil|mili[óo]|milion|bili[óo])s?)(?={FractionMultiplierRegex}?$)'
+    RoundMultiplierWithFraction = f'(?<=(?<!{RoundNumberIntegerRegex}){FractionMultiplierRegex}\\s+)?(?<multiplier>(?:cent|mil|mili[óo]|milion|bili[óo]|mil milions)s?)(?={FractionMultiplierRegex}?$)'
     RoundMultiplierRegex = f'\\b\\s*((de\\s+)?a\\s+)?({RoundMultiplierWithFraction}|(?<multiplier>(?:cent|mil|milers)s?)$)'
     FractionNounRegex = f'(?<=\\b)({AllIntRegex}\\s+(i\\s+)?)?({AllIntRegex}(\\s+((i)\\s)?)(({AllOrdinalNumberRegex}s?|{RoundNumberOrdinalRegex}s?)|(mig|meitats?|terç(os)?|quarts?))|(un\s+)?(mig|meitats?|terç(os)?|quarts?)(\s+(de\s+)?|\s*-\s*){RoundNumberIntegerRegex})(?=\\b)'
     FractionNounWithArticleRegex = f'(?<=\\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\\s+((i|con)\\s+)?)?((un|i)(\s+)(({AllOrdinalNumberRegex}))|(i\s+)?mig|meitats?|quarts?)(?=\\b)'
@@ -139,6 +139,8 @@ class CatalanNumeric:
                               ("bilió", 1000000000000),
                               ("centenars", 100),
                               ("milers", 1000),
+                              ("milion", 1000000),
+                              ("mil milions", 1000000000),
                               ("milers de milions", 1000000000),
                               ("bilions", 1000000000000)])
     OrdinalNumberMap = dict([("primer", 1),
@@ -178,6 +180,7 @@ class CatalanNumeric:
     RoundNumberMap = dict([("cent", 100),
                            ("mil", 1000),
                            ("milions", 1000000),
+                           ("milion", 1000000),
                            ("milió", 1000000),
                            ("mln", 1000000),
                            ("mil milions", 1000000000),

--- a/Python/libraries/recognizers-number/recognizers_number/resources/catalan_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/catalan_numeric.py
@@ -72,7 +72,8 @@ class CatalanNumeric:
     WrittenGroupSeparatorTexts = [r'punt(o)?']
     WrittenIntegerSeparatorTexts = [r'i']
     WrittenFractionSeparatorTexts = [r'i', r'de', r'd\'']
-    OneHalfTokens = [r'un', r'mig', r'quart', r'terç', r'terços', r'cinque']
+    FractionWithoutNumeratorToken = r'un'
+    FractionalTokens = [r'mig', r'quart', r'terç', r'terços', r'cinque']
     HalfADozenRegex = f'mitja\\s+dotzena'
     DigitalNumberRegex = f'((?<=\\b)(cent|milers|mil|milions|mil milions|bili[óo])(?=\\b))|((?<=(\\d|\\b)){BaseNumbers.MultiplierLookupRegex}(?=\\b))'
     CardinalNumberMap = dict([("zero", 0),
@@ -149,6 +150,7 @@ class CatalanNumeric:
                              ("mig", 2),
                              ("la meitat", 2),
                              ("tercer", 3),
+                             ("terç", 3),
                              ("quart", 4),
                              ("cinquè", 5),
                              ("sisè", 6),

--- a/Python/libraries/recognizers-number/recognizers_number/resources/catalan_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/catalan_numeric.py
@@ -7,7 +7,7 @@ class CatalanNumeric:
     CompoundNumberLanguage = False
     MultiDecimalSeparatorCulture = True
     NonStandardSeparatorVariants = []
-    RoundNumberIntegerRegex = f'((?:cents|milers|milions|mil milions|bilió)s?|mil)'
+    RoundNumberIntegerRegex = f'((?:cents|milers|milions|milió|mil milions|bilió)s?|mil)'
     ZeroToNineIntegerRegex = f'(?:tres|set|vuit|quatre|cinc|zero|nou|un|dos|sis)'
     TwoToNineIntegerRegex = f'(?:tres|set|vuit|quatre|cinc|nou|dos|sis)'
     NegativeNumberTermsRegex = f'(?<negTerm>(menys|negatiu)\\s+)'
@@ -39,6 +39,14 @@ class CatalanNumeric:
     AllOrdinalNumberRegex = f'(?:{SuffixRoundNumberOrdinalRegex})'
     AllOrdinalRegex = f'(?:{AllOrdinalNumberRegex})'
     OrdinalSuffixRegex = f'(?<=\\b)(?:(\\d*(1r|2n|3r|4t|[5-99][èe])))(?=\\b)'
+    FractionNotationWithSpacesRegex = f'(((?<=\\W|^)-\\s*)|(?<=\\b))\\d+\\s+\\d+[/]\\d+(?=(\\b[^/]|$))'
+    FractionNotationRegex = f'{BaseNumbers.FractionNotationRegex}'
+    FractionMultiplierRegex = f'(?<fracMultiplier>(\\s+(i|un)\\s+)(i|un(a)?|dues|{TwoToNineIntegerRegex}\\s+)?(mig|quarts?|terç|cinquè|sisè|setena|vuitè|vuitena|novè|desè)s?(\\s+(de|d\'))?)'
+    RoundMultiplierWithFraction = f'(?<=(?<!{RoundNumberIntegerRegex}){FractionMultiplierRegex}\\s+)?(?<multiplier>(?:mil|mili[óo]|milion|bili[óo])s?)(?={FractionMultiplierRegex}?$)'
+    RoundMultiplierRegex = f'\\b\\s*((de\\s+)?a\\s+)?({RoundMultiplierWithFraction}|(?<multiplier>(?:cent|mil|milers)s?)$)'
+    FractionNounRegex = f'(?<=\\b)({AllIntRegex}\\s+(i\\s+)?)?({AllIntRegex}(\\s+((i)\\s)?)(({AllOrdinalNumberRegex}s?|{RoundNumberOrdinalRegex}s?)|(mig|meitats?|terç(os)?|quarts?))|(un\s+)?(mig|meitats?|terç(os)?|quarts?)(\s+(de\s+)?|\s*-\s*){RoundNumberIntegerRegex})(?=\\b)'
+    FractionNounWithArticleRegex = f'(?<=\\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\\s+((i|con)\\s+)?)?((un|i)(\s+)(({AllOrdinalNumberRegex}))|(i\s+)?mig|meitats?|quarts?)(?=\\b)'
+    FractionPrepositionRegex = f'(?<!{BaseNumbers.CommonCurrencySymbol}\\s*)(?<=\\b)(?<numerator>({AllIntRegex})|((?<![\\.,])\d+))\\s+(sobre|(?<ambiguousSeparator>en|de))\\s+(?<denominator>({AllIntRegex})|(\d+)(?![\\.,]))(?=\\b)'
     AllPointRegex = f'((\\s+{ZeroToNineIntegerRegex})+|(\\s+{SeparaIntRegex}))'
     AllFloatRegex = f'{AllIntRegex}(\\s+coma){AllPointRegex}'
 
@@ -56,12 +64,15 @@ class CatalanNumeric:
     EqualRegex = f'(igual a)'
     AmbiguousFractionConnectorsRegex = f'(\\b(en|a)\\b)'
     DecimalSeparatorChar = ','
+    FractionMarkerToken = 'sobre'
     NonDecimalSeparatorChar = '.'
     HalfADozenText = 'sis'
     WordSeparatorToken = 'i'
     WrittenDecimalSeparatorTexts = [r'coma']
     WrittenGroupSeparatorTexts = [r'punt(o)?']
     WrittenIntegerSeparatorTexts = [r'i']
+    WrittenFractionSeparatorTexts = [r'i', r'de', r'd\'']
+    OneHalfTokens = [r'un', r'mig', r'quart', r'terç', r'terços', r'cinque']
     HalfADozenRegex = f'mitja\\s+dotzena'
     DigitalNumberRegex = f'((?<=\\b)(cent|milers|mil|milions|mil milions|bili[óo])(?=\\b))|((?<=(\\d|\\b)){BaseNumbers.MultiplierLookupRegex}(?=\\b))'
     CardinalNumberMap = dict([("zero", 0),
@@ -124,6 +135,7 @@ class CatalanNumeric:
                               ("noucents", 900),
                               ("mil", 1000),
                               ("milions", 1000000),
+                              ("milió", 1000000),
                               ("bilió", 1000000000000),
                               ("centenars", 100),
                               ("milers", 1000),
@@ -132,6 +144,7 @@ class CatalanNumeric:
     OrdinalNumberMap = dict([("primer", 1),
                              ("segon", 2),
                              ("secundari", 2),
+                             ("mig", 2),
                              ("la meitat", 2),
                              ("tercer", 3),
                              ("quart", 4),
@@ -165,6 +178,7 @@ class CatalanNumeric:
     RoundNumberMap = dict([("cent", 100),
                            ("mil", 1000),
                            ("milions", 1000000),
+                           ("milió", 1000000),
                            ("mln", 1000000),
                            ("mil milions", 1000000000),
                            ("bln", 1000000000),

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.88a2"
+VERSION = "1.0.88a3"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.88a0"
+VERSION = "1.0.88a1"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.88a1"
+VERSION = "1.0.88a2"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.87"
+VERSION = "1.0.88a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.88a3"
+VERSION = "1.0.88"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.87"
+VERSION = "1.0.88a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.88a0"
+VERSION = "1.0.88a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.88a2"
+VERSION = "1.0.88a3"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.88a3"
+VERSION = "1.0.88"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.88a1"
+VERSION = "1.0.88a2"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.88a3'
+VERSION = '1.0.88'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.88a3',
-    'recognizers-text-number-genesys==1.0.88a3',
-    'recognizers-text-number-with-unit-genesys==1.0.88a3',
-    'recognizers-text-date-time-genesys==1.0.88a3',
-    'recognizers-text-sequence-genesys==1.0.88a3',
-    'recognizers-text-choice-genesys==1.0.88a3',
-    'datatypes_timex_expression_genesys==1.0.88a3'
+    'recognizers-text-genesys==1.0.88',
+    'recognizers-text-number-genesys==1.0.88',
+    'recognizers-text-number-with-unit-genesys==1.0.88',
+    'recognizers-text-date-time-genesys==1.0.88',
+    'recognizers-text-sequence-genesys==1.0.88',
+    'recognizers-text-choice-genesys==1.0.88',
+    'datatypes_timex_expression_genesys==1.0.88'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.88a0'
+VERSION = '1.0.88a1'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.88a0',
-    'recognizers-text-number-genesys==1.0.88a0',
-    'recognizers-text-number-with-unit-genesys==1.0.88a0',
-    'recognizers-text-date-time-genesys==1.0.88a0',
-    'recognizers-text-sequence-genesys==1.0.88a0',
-    'recognizers-text-choice-genesys==1.0.88a0',
-    'datatypes_timex_expression_genesys==1.0.88a0'
+    'recognizers-text-genesys==1.0.88a1',
+    'recognizers-text-number-genesys==1.0.88a1',
+    'recognizers-text-number-with-unit-genesys==1.0.88a1',
+    'recognizers-text-date-time-genesys==1.0.88a1',
+    'recognizers-text-sequence-genesys==1.0.88a1',
+    'recognizers-text-choice-genesys==1.0.88a1',
+    'datatypes_timex_expression_genesys==1.0.88a1'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.87'
+VERSION = '1.0.88a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.87',
-    'recognizers-text-number-genesys==1.0.87',
-    'recognizers-text-number-with-unit-genesys==1.0.87',
-    'recognizers-text-date-time-genesys==1.0.87',
-    'recognizers-text-sequence-genesys==1.0.87',
-    'recognizers-text-choice-genesys==1.0.87',
-    'datatypes_timex_expression_genesys==1.0.87'
+    'recognizers-text-genesys==1.0.88a0',
+    'recognizers-text-number-genesys==1.0.88a0',
+    'recognizers-text-number-with-unit-genesys==1.0.88a0',
+    'recognizers-text-date-time-genesys==1.0.88a0',
+    'recognizers-text-sequence-genesys==1.0.88a0',
+    'recognizers-text-choice-genesys==1.0.88a0',
+    'datatypes_timex_expression_genesys==1.0.88a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.88a2'
+VERSION = '1.0.88a3'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.88a2',
-    'recognizers-text-number-genesys==1.0.88a2',
-    'recognizers-text-number-with-unit-genesys==1.0.88a2',
-    'recognizers-text-date-time-genesys==1.0.88a2',
-    'recognizers-text-sequence-genesys==1.0.88a2',
-    'recognizers-text-choice-genesys==1.0.88a2',
-    'datatypes_timex_expression_genesys==1.0.88a2'
+    'recognizers-text-genesys==1.0.88a3',
+    'recognizers-text-number-genesys==1.0.88a3',
+    'recognizers-text-number-with-unit-genesys==1.0.88a3',
+    'recognizers-text-date-time-genesys==1.0.88a3',
+    'recognizers-text-sequence-genesys==1.0.88a3',
+    'recognizers-text-choice-genesys==1.0.88a3',
+    'datatypes_timex_expression_genesys==1.0.88a3'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.88a1'
+VERSION = '1.0.88a2'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.88a1',
-    'recognizers-text-number-genesys==1.0.88a1',
-    'recognizers-text-number-with-unit-genesys==1.0.88a1',
-    'recognizers-text-date-time-genesys==1.0.88a1',
-    'recognizers-text-sequence-genesys==1.0.88a1',
-    'recognizers-text-choice-genesys==1.0.88a1',
-    'datatypes_timex_expression_genesys==1.0.88a1'
+    'recognizers-text-genesys==1.0.88a2',
+    'recognizers-text-number-genesys==1.0.88a2',
+    'recognizers-text-number-with-unit-genesys==1.0.88a2',
+    'recognizers-text-date-time-genesys==1.0.88a2',
+    'recognizers-text-sequence-genesys==1.0.88a2',
+    'recognizers-text-choice-genesys==1.0.88a2',
+    'datatypes_timex_expression_genesys==1.0.88a2'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.88a0"
+VERSION = "1.0.88a1"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.87"
+VERSION = "1.0.88a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.88a3"
+VERSION = "1.0.88"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.88a1"
+VERSION = "1.0.88a2"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.88a2"
+VERSION = "1.0.88a3"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/Number/Catalan/NumberModel.json
+++ b/Specs/Number/Catalan/NumberModel.json
@@ -218,5 +218,20 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Tinc un quart de milió d'euros",
+    "Results": [
+      {
+        "Text": "un quart de milió",
+        "Start": 5,
+        "End": 21,
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "250000"
+        }
+      }
+    ]
   }
 ]

--- a/Specs/Number/Catalan/NumberModel.json
+++ b/Specs/Number/Catalan/NumberModel.json
@@ -188,5 +188,35 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Puc aconseguir 5 milions i mig de dòlars?",
+    "Results": [
+      {
+        "Text": "5 milions i mig",
+        "Start": 15,
+        "End": 29,
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "5500000"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "On és el meu mig milió de dòlars?",
+    "Results": [
+      {
+        "Text": "mig milió",
+        "Start": 13,
+        "End": 21,
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "500000"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
mig ‘half’ was not being recognized as (part of) numeral:
- 5 milions i mig ‘5 million and a half’ ==> 5000000
- mig milió ‘half a million’ ==> None

This was due to missing regex in the ```Catalan_numeric.py``` file which involved implementing fractional support for catalan itself