### PR TITLE
[NLU-4000] Arabic Number: Comma-Decimal bug

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/NumbersDefinitions.cs
@@ -105,9 +105,9 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public static readonly string TwoNumberRangeRegex3 = $@"({OneNumberRangeLessRegex1}|{OneNumberRangeLessRegex2})\s*(،)?\s*((أ|ا)?و|لكن|,)\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})";
       public static readonly string TwoNumberRangeRegex4 = $@"((من\s)(?<number1>({NumberSplitMark}(?!\bمن\b).)+)\s*{TillRegex}\s*(ال\s+)?(?<number2>({NumberSplitMark}.)+))|((من\s)?(?<number1>({NumberSplitMark}(?!\bمن\b).)+)\s*{TillRegex}\s*(ال\s+)?(?<number2>({NumberSplitMark}.)+))";
       public const string AmbiguousFractionConnectorsRegex = @"(\bمن|بين|من|بين\b)";
-      public const char DecimalSeparatorChar = ',';
+      public const char DecimalSeparatorChar = '.';
       public const string FractionMarkerToken = @"أكثر";
-      public const char NonDecimalSeparatorChar = '،';
+      public const char NonDecimalSeparatorChar = ',';
       public const string HalfADozenText = @"ستة";
       public const string WordSeparatorToken = @"و";
       public static readonly string[] WrittenDecimalSeparatorTexts = { @"نقطة | فاصلة" };

--- a/Patterns/Arabic/Arabic-Numbers.yaml
+++ b/Patterns/Arabic/Arabic-Numbers.yaml
@@ -270,9 +270,9 @@ AmbiguousFractionConnectorsRegex: !simpleRegex
   def: (\bمن|بين|من|بين\b)
 # "in" is ambiguous for cases like "more than 30000 in 2009", other connector "out of", "over" is not ambiguous in English
 #Parser
-DecimalSeparatorChar: !char ","
+DecimalSeparatorChar: !char "."
 FractionMarkerToken: أكثر
-NonDecimalSeparatorChar: !char "،"
+NonDecimalSeparatorChar: !char ","
 HalfADozenText: ستة
 WordSeparatorToken: و
 WrittenDecimalSeparatorTexts: [نقطة | فاصلة]

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.88'
+VERSION = '1.0.89'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.88'
+VERSION = '1.0.89'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.88'
+VERSION = '1.0.89'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.88"
+VERSION = "1.0.89"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
@@ -106,9 +106,9 @@ class ArabicNumeric:
     TwoNumberRangeRegex3 = f'({OneNumberRangeLessRegex1}|{OneNumberRangeLessRegex2})\\s*(،)?\\s*((أ|ا)?و|لكن|,)\\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})'
     TwoNumberRangeRegex4 = f'((من\\s)(?<number1>({NumberSplitMark}(?!\\bمن\\b).)+)\\s*{TillRegex}\\s*(ال\\s+)?(?<number2>({NumberSplitMark}.)+))|((من\\s)?(?<number1>({NumberSplitMark}(?!\\bمن\\b).)+)\\s*{TillRegex}\\s*(ال\\s+)?(?<number2>({NumberSplitMark}.)+))'
     AmbiguousFractionConnectorsRegex = f'(\\bمن|بين|من|بين\\b)'
-    DecimalSeparatorChar = ','
+    DecimalSeparatorChar = '.'
     FractionMarkerToken = 'أكثر'
-    NonDecimalSeparatorChar = '،'
+    NonDecimalSeparatorChar = ','
     HalfADozenText = 'ستة'
     WordSeparatorToken = 'و'
     WrittenDecimalSeparatorTexts = [r'نقطة | فاصلة']

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.88"
+VERSION = "1.0.89"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.88"
+VERSION = "1.0.89"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.88'
+VERSION = '1.0.89'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.88',
-    'recognizers-text-number-genesys==1.0.88',
-    'recognizers-text-number-with-unit-genesys==1.0.88',
-    'recognizers-text-date-time-genesys==1.0.88',
-    'recognizers-text-sequence-genesys==1.0.88',
-    'recognizers-text-choice-genesys==1.0.88',
-    'datatypes_timex_expression_genesys==1.0.88'
+    'recognizers-text-genesys==1.0.89',
+    'recognizers-text-number-genesys==1.0.89',
+    'recognizers-text-number-with-unit-genesys==1.0.89',
+    'recognizers-text-date-time-genesys==1.0.89',
+    'recognizers-text-sequence-genesys==1.0.89',
+    'recognizers-text-choice-genesys==1.0.89',
+    'datatypes_timex_expression_genesys==1.0.89'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.88"
+VERSION = "1.0.89"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -175,7 +175,7 @@
   {
     "Input": "مائة وستة عشر صفحة",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "مائة وستة عشر",
@@ -192,7 +192,7 @@
   {
     "Input": "مائة وستة صفحات.",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "مائة وستة",
@@ -580,7 +580,7 @@
   {
     "Input": "عدد سكان المنطقة واحد وعشرون تريليون",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "واحد وعشرون تريليون",
@@ -597,7 +597,7 @@
   {
     "Input": "عدد سكان المنطقة واحد وعشرون تريليون وثلاث مائة",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "واحد وعشرون تريليون وثلاث مائة",
@@ -648,7 +648,7 @@
   {
     "Input": "يوجد في الغابة  ثلاث مائة وواحد وثلاثون  أشجار",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "ثلاث مائة وواحد وثلاثون",
@@ -750,7 +750,7 @@
   {
     "Input": "٣/٤ الكأس",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "٣/٤",
@@ -1425,7 +1425,7 @@
   },
   {
     "Input": "حجزت رحلتي في درجة الأولى",
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": []
   },
   {
@@ -1645,22 +1645,22 @@
   },
   {
     "Input": "الذي ذكرتها كان باطلا.",
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": []
   },
   {
     "Input": "الدي ذكرتها كانت غير صحيحة.",
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": []
   },
   {
     "Input": "أي واحد تفضل؟",
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": []
   },
   {
     "Input": "هذاك جيد حقا.",
-    "NotSupportedByDesign": "javascript, java, xython",
+    "NotSupportedByDesign": "javascript, java",
     "Results": []
   },
   {
@@ -2340,7 +2340,7 @@
   {
     "Input": "192.",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2401,7 +2401,7 @@
   {
     "Input": "السائل 180.25 مل",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2418,7 +2418,7 @@
   {
     "Input": "السائل 180 مل",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2435,7 +2435,7 @@
   {
     "Input": " طريق 29 كم ",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2452,7 +2452,7 @@
   {
     "Input": " 4 مايو ",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2475,7 +2475,7 @@
   {
     "Input": ".08",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2492,7 +2492,7 @@
   {
     "Input": "واحد",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2509,7 +2509,7 @@
   {
     "Input": "مفرد",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": []
   },
   {
@@ -2530,13 +2530,13 @@
     ]
   },
   {
-    "Input": "4,800",
+    "Input": "4.800",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "4,800",
+        "Text": "4.800",
         "TypeName": "number",
         "Resolution": {
           "value": "4.8"
@@ -2668,7 +2668,7 @@
   {
     "Input": "مائة و واحد و ستون",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2785,13 +2785,13 @@
     ]
   },
   {
-    "Input": "1.234.567",
+    "Input": "1,234,567",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "1.234.567",
+        "Text": "1,234,567",
         "TypeName": "number",
         "Resolution": {
           "value": "1234567"
@@ -2856,7 +2856,7 @@
   {
     "Input": " -9,2321312",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3264,7 +3264,7 @@
   {
     "Input": "3/4",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4543,7 +4543,7 @@
   {
     "Input": "1M ليس رقما.",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": []
   },
   {
@@ -4704,31 +4704,31 @@
   {
     "Input": "الشخص الذي ذكرته غير صالح",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": []
   },
   {
     "Input": "هذا غير صحيح",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": []
   },
   {
     "Input": "أي شخص تفضل؟",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": []
   },
   {
     "Input": "هذا جيد حقاً",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,xython,java",
+    "NotSupportedByDesign": "javascript,java",
     "Results": []
   },
   {
     "Input": "في بعض البلدان يمكنك كتابة 5.00 أو 5,00.",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4894,11 +4894,11 @@
     ]
   },
   {
-    "Input": "12،220,13",
+    "Input": "12,220.13",
     "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
-        "Text": "12،220,13",
+        "Text": "12,220.13",
         "TypeName": "number",
         "Resolution": {
           "subtype": "decimal",
@@ -4906,6 +4906,38 @@
         },
         "Start": 0,
         "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "60,000",
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "60,000",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "decimal",
+          "value": "60000"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "11.50",
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "11.50",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "decimal",
+          "value": "11.5"
+        },
+        "Start": 0,
+        "End": 4
       }
     ]
   }

--- a/Specs/NumberWithUnit/Arabic/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Arabic/CurrencyModel.json
@@ -126,5 +126,36 @@
         }
       }
     ]
+  },
+  {
+    "Input": "أرغب في شراء هذا المنتج مقابل 11.50 يورو",
+    "Results": [
+      {
+        "Text": "11.50 يورو",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "11.5",
+          "unit": "Euro",
+          "isoCurrency": "EUR"
+        },
+        "Start": 30,
+        "End": 39
+      }
+    ]
+  },
+  {
+    "Input": "أرغب في شراء هذا المنتج بمبلغ 60,000 جنيه إسترليني",
+    "Results": [
+      {
+        "Text": "60,000 جنيه إسترليني",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "60000",
+          "unit": "Egyptian pound"
+        },
+        "Start": 30,
+        "End": 49
+      }
+    ]
   }
 ]


### PR DESCRIPTION
UAE Arabic uses comma ',' as a thousands separator and point '.' as a decimal mark:  [Decimal separator](https://en.wikipedia.org/wiki/Decimal_separator#Countries_using_decimal_point) ; currently we are doing the exact reverse:

* 60,000 => 60 (should be 60000)
* 11.50 => 1150 (should be 11.5)

This affects currency and number.