### PR TITLE
[NLU-4047] - Fix for dates with hyphen not working and added tests

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.97'
+VERSION = '1.0.99a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.99a1'
+VERSION = '1.0.100'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.99a0'
+VERSION = '1.0.99'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.0.99'
+VERSION = '1.0.99a1'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.97'
+VERSION = '1.0.99a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.99'
+VERSION = '1.0.99a1'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.99a0'
+VERSION = '1.0.99'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.0.99a1'
+VERSION = '1.0.100'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/abstract_year_extractor.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/abstract_year_extractor.py
@@ -67,10 +67,9 @@ class AbstractYearExtractor(DateExtractor):
                 if (first_two_year_num < 100 and last_two_year_num == 0)\
                         or (first_two_year_num < 100 and first_two_year_num % 10 == 0
                             and (len(last_two_year_num_str.strip().split(' ')) == 1 and
-                                 len(last_two_year_num_str.strip().split('-')) == 1)):
-                    if (first_two_year_num + last_two_year_num) < 30:
-                        year = Constants.INVALID_YEAR
-                        return year
+                                 len(last_two_year_num_str.strip().split('-')) == 1 and last_two_year_num < 10)):
+                    year = Constants.INVALID_YEAR
+                    return year
 
                 if first_two_year_num >= 100:
                     year = first_two_year_num + last_two_year_num

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/abstract_year_extractor.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/abstract_year_extractor.py
@@ -66,9 +66,11 @@ class AbstractYearExtractor(DateExtractor):
                 # Exclude pure number like "nineteen", "twenty four"
                 if (first_two_year_num < 100 and last_two_year_num == 0)\
                         or (first_two_year_num < 100 and first_two_year_num % 10 == 0
-                            and len(last_two_year_num_str.strip().split(' ')) == 1):
-                    year = Constants.INVALID_YEAR
-                    return year
+                            and (len(last_two_year_num_str.strip().split(' ')) == 1 and
+                                 len(last_two_year_num_str.strip().split('-')) == 1)):
+                    if (first_two_year_num + last_two_year_num) < 30:
+                        year = Constants.INVALID_YEAR
+                        return year
 
                 if first_two_year_num >= 100:
                     year = first_two_year_num + last_two_year_num

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -46,7 +46,7 @@ class EnglishDateTime:
     WrittenCenturyFullYearRegex = f'(?:(one|two)\\s+thousand((\\s+and)?\\s+{WrittenOneToNineRegex}\\s+hundred)?)'
     WrittenCenturyOrdinalYearRegex = f'(?:twenty(\\s+(one|two))?|ten|eleven|twelve|thirteen|fifteen|eighteen|(?:four|six|seven|nine)(teen)?|one|two|three|five|eight)'
     CenturyRegex = f'\\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\\s+hundred)?)\\b'
-    LastTwoYearNumRegex = f'(?:(zero\\s+)?{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\\s+{WrittenOneToNineRegex})?)'
+    LastTwoYearNumRegex = f'(?:(zero\\s+)?{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}((\\s+|-){WrittenOneToNineRegex})?)'
     FullTextYearRegex = f'\\b((?<firsttwoyearnum>{CenturyRegex})(\\s+and)?\\s+(?<lasttwoyearnum>{LastTwoYearNumRegex})\\b|\\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\\s+hundred))\\b'
     OclockRegex = f'(?<oclock>o\\s*((’|‘|\')\\s*)?clock|sharp)'
     SpecialDescRegex = f'((?<ipm>)p\\b)'

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.99a1'
+VERSION = '1.0.100'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.97'
+VERSION = '1.0.99a0'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.99a0'
+VERSION = '1.0.99'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.0.99'
+VERSION = '1.0.99a1'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.99a0"
+VERSION = "1.0.99"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.99"
+VERSION = "1.0.99a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.97"
+VERSION = "1.0.99a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.0.99a1"
+VERSION = "1.0.100"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.97"
+VERSION = "1.0.99a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.99a0"
+VERSION = "1.0.99"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.99"
+VERSION = "1.0.99a1"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.0.99a1"
+VERSION = "1.0.100"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.99a1"
+VERSION = "1.0.100"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.99a0"
+VERSION = "1.0.99"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.97"
+VERSION = "1.0.99a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.0.99"
+VERSION = "1.0.99a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.97'
+VERSION = '1.0.99a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.97',
-    'recognizers-text-number-genesys==1.0.97',
-    'recognizers-text-number-with-unit-genesys==1.0.97',
-    'recognizers-text-date-time-genesys==1.0.97',
-    'recognizers-text-sequence-genesys==1.0.97',
-    'recognizers-text-choice-genesys==1.0.97',
-    'datatypes_timex_expression_genesys==1.0.97'
+    'recognizers-text-genesys==1.0.99a0',
+    'recognizers-text-number-genesys==1.0.99a0',
+    'recognizers-text-number-with-unit-genesys==1.0.99a0',
+    'recognizers-text-date-time-genesys==1.0.99a0',
+    'recognizers-text-sequence-genesys==1.0.99a0',
+    'recognizers-text-choice-genesys==1.0.99a0',
+    'datatypes_timex_expression_genesys==1.0.99a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.99a0'
+VERSION = '1.0.99'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.99a0',
-    'recognizers-text-number-genesys==1.0.99a0',
-    'recognizers-text-number-with-unit-genesys==1.0.99a0',
-    'recognizers-text-date-time-genesys==1.0.99a0',
-    'recognizers-text-sequence-genesys==1.0.99a0',
-    'recognizers-text-choice-genesys==1.0.99a0',
-    'datatypes_timex_expression_genesys==1.0.99a0'
+    'recognizers-text-genesys==1.0.99',
+    'recognizers-text-number-genesys==1.0.99',
+    'recognizers-text-number-with-unit-genesys==1.0.99',
+    'recognizers-text-date-time-genesys==1.0.99',
+    'recognizers-text-sequence-genesys==1.0.99',
+    'recognizers-text-choice-genesys==1.0.99',
+    'datatypes_timex_expression_genesys==1.0.99'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.99'
+VERSION = '1.0.99a1'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.99',
-    'recognizers-text-number-genesys==1.0.99',
-    'recognizers-text-number-with-unit-genesys==1.0.99',
-    'recognizers-text-date-time-genesys==1.0.99',
-    'recognizers-text-sequence-genesys==1.0.99',
-    'recognizers-text-choice-genesys==1.0.99',
-    'datatypes_timex_expression_genesys==1.0.99'
+    'recognizers-text-genesys==1.0.99a1',
+    'recognizers-text-number-genesys==1.0.99a1',
+    'recognizers-text-number-with-unit-genesys==1.0.99a1',
+    'recognizers-text-date-time-genesys==1.0.99a1',
+    'recognizers-text-sequence-genesys==1.0.99a1',
+    'recognizers-text-choice-genesys==1.0.99a1',
+    'datatypes_timex_expression_genesys==1.0.99a1'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.0.99a1'
+VERSION = '1.0.100'
 REQUIRES = [
-    'recognizers-text-genesys==1.0.99a1',
-    'recognizers-text-number-genesys==1.0.99a1',
-    'recognizers-text-number-with-unit-genesys==1.0.99a1',
-    'recognizers-text-date-time-genesys==1.0.99a1',
-    'recognizers-text-sequence-genesys==1.0.99a1',
-    'recognizers-text-choice-genesys==1.0.99a1',
-    'datatypes_timex_expression_genesys==1.0.99a1'
+    'recognizers-text-genesys==1.0.100',
+    'recognizers-text-number-genesys==1.0.100',
+    'recognizers-text-number-with-unit-genesys==1.0.100',
+    'recognizers-text-date-time-genesys==1.0.100',
+    'recognizers-text-sequence-genesys==1.0.100',
+    'recognizers-text-choice-genesys==1.0.100',
+    'datatypes_timex_expression_genesys==1.0.100'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.99"
+VERSION = "1.0.99a1"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.99a0"
+VERSION = "1.0.99"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.97"
+VERSION = "1.0.99a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.0.99a1"
+VERSION = "1.0.100"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/DateTime/English/DateExtractor.json
+++ b/Specs/DateTime/English/DateExtractor.json
@@ -1839,5 +1839,60 @@
         "Length": 10
       }
     ]
+  },
+  {
+    "Input": "I was born on January eleventh nineteen seventy-four",
+    "Results": [
+      {
+        "Text": "january eleventh nineteen seventy-four",
+        "Type": "date",
+        "Start": 14,
+        "Length": 38
+      }
+    ]
+  },
+  {
+    "Input": "Aliens will land on earth on the fourth of july twenty twenty-seven",
+    "Results": [
+      {
+        "Text": "fourth of july twenty twenty-seven",
+        "Type": "date",
+        "Start": 33,
+        "Length": 34
+      }
+    ]
+  },
+  {
+    "Input": "My car insurance expires on June first twenty twenty",
+    "Results": [
+      {
+        "Text": "june first twenty twenty",
+        "Type": "date",
+        "Start": 28,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "Is there anything for March the second twenty fourteen",
+    "Results": [
+      {
+        "Text": "march the second twenty fourteen",
+        "Type": "date",
+        "Start": 22,
+        "Length": 32
+      }
+    ]
+  },
+  {
+    "Input": "Do you remember the twenty-second of july nineteen forty-eight",
+    "Results": [
+      {
+        "Text": "twenty-second of july nineteen forty-eight",
+        "Type": "date",
+        "Start": 20,
+        "Length": 42
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateParser.json
+++ b/Specs/DateTime/English/DateParser.json
@@ -3453,5 +3453,120 @@
         "Length": 10
       }
     ]
+  },
+  {
+    "Input": "I was born on January eleventh nineteen seventy-four",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "january eleventh nineteen seventy-four",
+        "Type": "date",
+        "Value": {
+          "Timex": "1974-01-11",
+          "FutureResolution": {
+            "date": "1974-01-11"
+          },
+          "PastResolution": {
+            "date": "1974-01-11"
+          }
+        },
+        "Start": 14,
+        "Length": 38
+      }
+    ]
+  },
+  {
+    "Input": "Aliens will land on earth on the fourth of july twenty twenty-seven",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "fourth of july twenty twenty-seven",
+        "Type": "date",
+        "Value": {
+          "Timex": "2027-07-04",
+          "FutureResolution": {
+            "date": "2027-07-04"
+          },
+          "PastResolution": {
+            "date": "2027-07-04"
+          }
+        },
+        "Start": 33,
+        "Length": 34
+      }
+    ]
+  },
+  {
+    "Input": "Is there anything for March the second twenty fourteen",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "march the second twenty fourteen",
+        "Type": "date",
+        "Value": {
+          "Timex": "2014-03-02",
+          "FutureResolution": {
+            "date": "2014-03-02"
+          },
+          "PastResolution": {
+            "date": "2014-03-02"
+          }
+        },
+        "Start": 22,
+        "Length": 32
+      }
+    ]
+  },
+  {
+    "Input": "Do you remember the twenty-second of july nineteen forty-eight",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "twenty-second of july nineteen forty-eight",
+        "Type": "date",
+        "Value": {
+          "Timex": "1948-07-22",
+          "FutureResolution": {
+            "date": "1948-07-22"
+          },
+          "PastResolution": {
+            "date": "1948-07-22"
+          }
+        },
+        "Start": 20,
+        "Length": 42
+      }
+    ]
+  },
+  {
+    "Input": "My car insurance expires on June first twenty twenty",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "june first twenty twenty",
+        "Type": "date",
+        "Value": {
+          "Timex": "2020-06-01",
+          "FutureResolution": {
+            "date": "2020-06-01"
+          },
+          "PastResolution": {
+            "date": "2020-06-01"
+          }
+        },
+        "Start": 28,
+        "Length": 24
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -25928,5 +25928,120 @@
         "TypeName": "datetimeV2.date"
       }
     ]
+  },
+  {
+    "Input": "I was born on January eleventh nineteen seventy-four",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Start": 14,
+        "End": 51,
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1974-01-11",
+              "type": "date",
+              "value": "1974-01-11"
+            }
+          ]
+        },
+        "Text": "january eleventh nineteen seventy-four",
+        "Type": "datetimeV2.date"
+      }
+    ]
+  },
+  {
+    "Input": "Aliens will land on earth on the fourth of july twenty twenty-seven",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Start": 33,
+        "End": 66,
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2027-07-04",
+              "type": "date",
+              "value": "2027-07-04"
+            }
+          ]
+        },
+        "Text": "fourth of july twenty twenty-seven",
+        "Type": "datetimeV2.date"
+      }
+    ]
+  },
+  {
+    "Input": "My car insurance expires on June first twenty twenty",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Start": 28,
+        "End": 51,
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-06-01",
+              "type": "date",
+              "value": "2020-06-01"
+            }
+          ]
+        },
+        "Text": "june first twenty twenty",
+        "Type": "datetimeV2.date"
+      }
+    ]
+  },
+  {
+    "Input": "Is there anything for March the second twenty fourteen",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Start": 22,
+        "End": 53,
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014-03-02",
+              "type": "date",
+              "value": "2014-03-02"
+            }
+          ]
+        },
+        "Text": "march the second twenty fourteen",
+        "Type": "datetimeV2.date"
+      }
+    ]
+  },
+  {
+    "Input": "Do you remember the twenty-second of july nineteen forty-eight",
+    "Context": {
+      "ReferenceDateTime": "2023-05-05T00:00:00"
+    },
+    "Results": [
+      {
+        "Start": 20,
+        "End": 61,
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1948-07-22",
+              "type": "date",
+              "value": "1948-07-22"
+            }
+          ]
+        },
+        "Text": "twenty-second of july nineteen forty-eight",
+        "Type": "datetimeV2.date"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
`{
    "input": {
        "text":"January eleventh nineteen seventy-four",
        "language": "en-us"
        },
    "context": {
        "entity": {
            "type": "builtin:date"
        }
    }
}`

was resolving as `1970-01-11` due to a missing hyphen (-) in the `english_date_time.py` regex file and missing logic in `abstract_year_extractor.py`. 

This PR also fixes 2 issues with similar phrases: 
1. `twenty twenty` resolving as `2024-xx-xx`  or `2025-xx-xx`
2. `twenty nineteen` (and similar phrases) not resolving at all

due to logic in `abstract_year_extractor.py`

Also added relevant tests