### PR TITLE
[NLU-4096] Arabic Date: Written year not resolving correctly

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.11'
+VERSION = '1.1.14'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.11'
+VERSION = '1.1.14'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/arabic_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/arabic_date_time.py
@@ -32,7 +32,7 @@ class ArabicDateTime:
     WrittenCenturyOrdinalYearRegex = f'(?<fullyear>({WrittenElevenToNineteenRegex}|مائة|مائتين)\\s+((و)\\s*)?({WrittenOneToNineRegex})\\s+(و)\\s*{WrittenTensRegex})'
     CenturyRegex = f'\\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\\s*مائة)?(\\s*و)?)\\b'
     LastTwoYearNumRegex = f'(?:zero\\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\\s+{WrittenOneToNineRegex})?)'
-    FullTextYearRegex = f'(?<firsttwoyearnum>{CenturyRegex})\\s*(?<lasttwoyearnum>{LastTwoYearNumRegex})|(?<firsttwoyearnum>{WrittenCenturyFullYearRegex})|{WrittenCenturyOrdinalYearRegex}'
+    FullTextYearRegex = f'(?<firsttwoyearnum>{CenturyRegex})\\s*(?<lasttwoyearnum>{LastTwoYearNumRegex})|{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}'
     OclockRegex = f'(?<oclock>(ال)?ساعة|(ال)?ساعات)'
     SpecialDescRegex = f'((?<ipm>)p\\b)'
     AmDescRegex = f'(في\\s)?(صباح(ا)?|صباحًا|ص|الصباح|{BaseDateTime.BaseAmDescRegex})'

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.11'
+VERSION = '1.1.14'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.11"
+VERSION = "1.1.14"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.11"
+VERSION = "1.1.14"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.11"
+VERSION = "1.1.14"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.11'
+VERSION = '1.1.14'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.11',
-    'recognizers-text-number-genesys==1.1.11',
-    'recognizers-text-number-with-unit-genesys==1.1.11',
-    'recognizers-text-date-time-genesys==1.1.11',
-    'recognizers-text-sequence-genesys==1.1.11',
-    'recognizers-text-choice-genesys==1.1.11',
-    'datatypes_timex_expression_genesys==1.1.11'
+    'recognizers-text-genesys==1.1.14',
+    'recognizers-text-number-genesys==1.1.14',
+    'recognizers-text-number-with-unit-genesys==1.1.14',
+    'recognizers-text-date-time-genesys==1.1.14',
+    'recognizers-text-sequence-genesys==1.1.14',
+    'recognizers-text-choice-genesys==1.1.14',
+    'datatypes_timex_expression_genesys==1.1.14'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.11"
+VERSION = "1.1.14"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/DateTime/Arabic/DateTimeModel.json
+++ b/Specs/DateTime/Arabic/DateTimeModel.json
@@ -5152,5 +5152,57 @@
         }
       }
     ]
+  },
+  {
+    "Input": "ألفين وخمسة عشر",
+    "Context": {
+      "ReferenceDateTime": "2024-02-21T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "java, javascript",
+    "Results": [
+      {
+        "Text": "ألفين وخمسة عشر",
+        "Start": 0,
+        "End": 14,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "ألفان وثلاثة وعشرون",
+    "Context": {
+      "ReferenceDateTime": "2024-02-21T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "java, javascript",
+    "Results": [
+      {
+        "Text": "ألفان وثلاثة وعشرون",
+        "Start": 0,
+        "End": 18,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2023",
+              "type": "daterange",
+              "start": "2023-01-01",
+              "end": "2024-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixing an issue with Arabic phrases for the written years. For example, the phrase "ألفان وثلاثة وعشرون" (two thousand and twenty three) was being resolved as "2046-01-01". The issue was fixed by removing the extra capturing group from the FullTextYearRegex regex.