### PR TITLE
[NLU-4109] Speed up Recognizers test suite

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -26,9 +26,17 @@ You can then install each of the local packages:
     pip install -e .\libraries\recognizers-number-with-unit\
     pip install -e .\libraries\recognizers-date-time\
 
-To run tests:
+To run all tests:
 
-    pytest --tb=line
+    pytest --tb=line -n auto
+
+To run a specific test suite, use one of the following commands:
+
+    pytest -n auto tests/test_runner_choice.py
+    pytest -n auto tests/test_runner_datetime.py
+    pytest -n auto tests/test_runner_number.py
+    pytest -n auto tests/test_runner_number_with_unit.py
+    pytest -n auto tests/test_runner_sequence.py
 
 ### Automatized Build
 

--- a/Python/build.sh
+++ b/Python/build.sh
@@ -26,4 +26,4 @@ echo // Installing Test Dependencies
 pip install -r ./tests/requirements.txt
 
 echo // Running tests
-pytest --tb=line
+pytest --tb=line -n auto

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.15'
+VERSION = '1.1.16'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.15'
+VERSION = '1.1.16'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.15'
+VERSION = '1.1.16'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.15"
+VERSION = "1.1.16"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.15"
+VERSION = "1.1.16"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.15"
+VERSION = "1.1.16"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.15'
+VERSION = '1.1.16'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.15',
-    'recognizers-text-number-genesys==1.1.15',
-    'recognizers-text-number-with-unit-genesys==1.1.15',
-    'recognizers-text-date-time-genesys==1.1.15',
-    'recognizers-text-sequence-genesys==1.1.15',
-    'recognizers-text-choice-genesys==1.1.15',
-    'datatypes_timex_expression_genesys==1.1.15'
+    'recognizers-text-genesys==1.1.16',
+    'recognizers-text-number-genesys==1.1.16',
+    'recognizers-text-number-with-unit-genesys==1.1.16',
+    'recognizers-text-date-time-genesys==1.1.16',
+    'recognizers-text-sequence-genesys==1.1.16',
+    'recognizers-text-choice-genesys==1.1.16',
+    'datatypes_timex_expression_genesys==1.1.16'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.15"
+VERSION = "1.1.16"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/tests/requirements.txt
+++ b/Python/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest-cov
 pytest>=3.2.0
+pytest-xdist==3.5.0


### PR DESCRIPTION
Introducing `pytest-xdist` to enable parallel execution of the Recognizers test suite and reduce the overall test execution time. As the Recognizers test suite has grown in size over time, the duration of test runs has also increased.

#### Changes
* Added `pytest-xdist` to the test dependencies
* Updated the test execution command to utilise the `-n auto` flag, which automatically determines the number of pytest-xdist workers based on the available CPU cores.