### PR TITLE
[NLU-4111] Arabic Number: spelled out numbers not resolving correctly

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.21'
+VERSION = '1.1.22'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.21'
+VERSION = '1.1.22'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.21'
+VERSION = '1.1.22'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.21"
+VERSION = "1.1.22"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
@@ -27,7 +27,7 @@ class ArabicNumeric:
     TenToNineteenIntegerRegex = f'(?:((ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنان|اثنين|اثتنين|اثنتان|إثنان|إثنتان|إثنين|إثتنين|إثنتان|ستة|أحد|أربعة|إثني|اثني)\\s(عشر|عشرة)))'
     TensNumberIntegerRegex = f'(عشرة|عشرون|ثلاثون|أربعون|خمسون|ستون|سبعون|ثمانون|تسعين|وعشرين|و عشرين|وثلاثين|و ثلاثين|وأربعين|و أربعين|وخمسين|و خمسين|وستين|وستين|وسبعين|و سبعين|وثمانين|و ثمانين|وتسعين|وتسعين|وعشرون|ثلاثون|وأربعون|و أربعون|وخمسون|و خمسون|وستون|و ستون|وسبعون|و سبعون|وثمانون|و ثمانون|وتسعون|و تسعون|عشرين|ثلاثين|أربعين|خمسين|ستين|سبعين|ثمانين|تسعون|العشرون:?)'
     SeparaIntRegex = f'(?:((({RoundNumberIntegerRegex}\\s{RoundNumberIntegerRegex})|{TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(((و)?)\\s+(و)?|\\s*-\\s*){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\\s+{RoundNumberIntegerRegex})*))|(((\\s+{RoundNumberIntegerRegex})+))'
-    AllIntRegex = f'(?:({SeparaIntRegex})((\\s+(و)?)({SeparaIntRegex})(\\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\\s+(و)?|\\s*-\\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?(\\s+{RoundNumberIntegerRegex})+)\\s+(و)?)*{SeparaIntRegex})'
+    AllIntRegex = f'(?:({SeparaIntRegex})((\\s*(و)\\s*)({SeparaIntRegex})(\\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\\s+(و)?|\\s*-\\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?(\\s+{RoundNumberIntegerRegex})+)\\s+(و)?)*{SeparaIntRegex})'
     PlaceHolderPureNumber = f'\\b'
     PlaceHolderDefault = f'\\D|\\b'
 
@@ -129,6 +129,7 @@ class ArabicNumeric:
                               ("اثنان", 2),
                               ("اثنين", 2),
                               ("الاثنين", 2),
+                              ("إثنان", 2),
                               ("الثلاثة", 3),
                               ("ثلاث", 3),
                               ("ثلاثة", 3),

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.21"
+VERSION = "1.1.22"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.21"
+VERSION = "1.1.22"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.21'
+VERSION = '1.1.22'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.21',
-    'recognizers-text-number-genesys==1.1.21',
-    'recognizers-text-number-with-unit-genesys==1.1.21',
-    'recognizers-text-date-time-genesys==1.1.21',
-    'recognizers-text-sequence-genesys==1.1.21',
-    'recognizers-text-choice-genesys==1.1.21',
-    'datatypes_timex_expression_genesys==1.1.21'
+    'recognizers-text-genesys==1.1.22',
+    'recognizers-text-number-genesys==1.1.22',
+    'recognizers-text-number-with-unit-genesys==1.1.22',
+    'recognizers-text-date-time-genesys==1.1.22',
+    'recognizers-text-sequence-genesys==1.1.22',
+    'recognizers-text-choice-genesys==1.1.22',
+    'datatypes_timex_expression_genesys==1.1.22'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.21"
+VERSION = "1.1.22"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -5536,5 +5536,87 @@
         "End": 8
       }
     ]
+  },
+  {
+    "Input": "ثلاثة إثنان واحد",
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "ثلاثة",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "3"
+        },
+        "Start": 0,
+        "End": 4
+      },
+      {
+        "Text": "إثنان",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2"
+        },
+        "Start": 6,
+        "End": 10
+      },
+      {
+        "Text": "واحد",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "1"
+        },
+        "Start": 12,
+        "End": 15
+      }
+    ]
+  },
+  {
+    "Input": "اثنان صفر اثنان أربعة",
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "اثنان",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2"
+        },
+        "Start": 0,
+        "End": 4
+      },
+      {
+        "Text": "صفر",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "0"
+        },
+        "Start": 6,
+        "End": 8
+      },
+      {
+        "Text": "اثنان",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2"
+        },
+        "Start": 10,
+        "End": 14
+      },
+      {
+        "Text": "أربعة",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "4"
+        },
+        "Start": 16,
+        "End": 20
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixing an issue with the resolution of Arabic spelled-out numbers that were not resolving correctly.

Example spelled out number from native speaker: اثنان صفر اثنان أربعة (two zero two four).