### PR TITLE
[NLU-4110] - Arabic (eastern) digits not resolved

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.23a0'
+VERSION = '1.1.23a1'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.22'
+VERSION = '1.1.23a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.25a0'
+VERSION = '1.1.25'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.22'
+VERSION = '1.1.23a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.23a0'
+VERSION = '1.1.23a1'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.25a0'
+VERSION = '1.1.25'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.23a0'
+VERSION = '1.1.23a1'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.25a0'
+VERSION = '1.1.25'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.22'
+VERSION = '1.1.23a0'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.22"
+VERSION = "1.1.23a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.23a0"
+VERSION = "1.1.23a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.25a0"
+VERSION = "1.1.25"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/recognizers_number/number/parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/parsers.py
@@ -755,7 +755,8 @@ class BaseNumberParser(Parser):
                     scale = getcontext().multiply(scale, Decimal(0.1))
                 else:
                     tmp = getcontext().add(getcontext().multiply(tmp, scale), Decimal(c))
-            elif c == decimal_separator or (not skippable_non_decimal and c == non_decimal_separator):
+            elif (c == decimal_separator or (not skippable_non_decimal and c == non_decimal_separator) or c in
+                  self.config.written_decimal_separator_texts):
                 has_decimal_separator = True
                 scale = Decimal(0.1)
             elif c == '-':

--- a/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
@@ -76,7 +76,7 @@ class ArabicNumeric:
     DoubleWithRoundNumber = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[.,])))\\d+\\u202A?[.,]\\u202A?\\d+\\s+{RoundNumberIntegerRegex}(?=\\b)'
 
     def DoubleWithThousandMarkRegex(placeholder):
-        return f'(((?<!\\d+\\s*)-\\s*)|((?<=\\b)(?<!\\d+\\.|\\d+,|\\d+)))\\d{{1,3}}(\\u202A?[٬،]\\u202A?\\d{{3}})+\\u202A?[.,،٬٫]\\u202A?\\d+(?={placeholder})'
+        return f'(((?<!\\d+\\s*)-\\s*)|((?<=\\b)(?<!\\d+[.,]?)))\\d{{1,3}}(\\u202A?[٬،]\\u202A?\\d{{3}})+\\u202A?[.,،٬٫]\\u202A?\\d+(?={placeholder})'
     DoubleAllFloatRegex = f'((?<=\\b){AllFloatRegex}(?=\\b))'
     ConnectorRegex = f'(?<spacer>و)'
     NumberWithSuffixPercentage = f'((?<!(٪|%))({BaseNumbers.NumberReplaceToken})(\\s*)((٪|%)(?!{BaseNumbers.NumberReplaceToken})|(بالمائة|في المئة|بالمئة)))'
@@ -113,7 +113,6 @@ class ArabicNumeric:
     DecimalSeparatorChar = '.'
     FractionMarkerToken = 'أكثر'
     NonDecimalSeparatorChar = ','
-    AlternateDecimalSeparatorChar = '٫'
     HalfADozenText = 'ستة'
     WordSeparatorToken = 'و'
     WrittenDecimalSeparatorTexts = [r'فاصلة', r'فاصل', r'نقاط', r'نقطة', r'٫']

--- a/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
@@ -32,7 +32,7 @@ class ArabicNumeric:
     PlaceHolderDefault = f'\\D|\\b'
 
     def NumbersWithPlaceHolder(placeholder):
-        return f'(((?<!\\d+\\s*)([-]\\s*)?)|(?<=\\b))\\d+(?!([\\.،,]\\d+[\\u0621-\\u064A]))(?={placeholder})'
+        return f'(((?<!\\d+\\s*)([-]\\s*)?)|(?<=\\b))\\d+(?!([.،,]\\d+[\\u0621-\\u064A]))(?={placeholder})'
     NumbersWithSuffix = f'(((?<!\\d+\\s*)([-]\\s*)?)|(?<=\\b))\\d+\\s*{BaseNumbers.NumberMultiplierRegex}(?=\\b)'
     RoundNumberIntegerRegexWithLocks = f'(?<=\\b)(\\d+\\s*({RoundNumberIntegerRegex})(\\s|و\\s|\\sو))?\\d+(\\s|و\\s|\\sو)+{RoundNumberIntegerRegex}((\\s*و\\s*)+\\d+)?(?=\\b)'
     NumbersWithDozenSuffix = f'(((?<!\\d+\\s*)([-]\\s*)?)|(?<=\\b))(\\d+\\s+)?(دستة|دستات|دست|دزينة|دزينات|دزينتين)(?=\\b)'
@@ -55,8 +55,8 @@ class ArabicNumeric:
     ArabicPartOfItem = '(?:أرباع|وربع|واحد وربع|نصف|ربع|أنصاف|ربعين|ارباع)'
     FractionNounRegex= f'(?<=\\b)({AllIntRegex}\\s+{ArabicAndRegex})?(({AllIntRegex})(\\s+|\\s*-\\s*)?((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))|أنصاف|أرباع)((\\s+من\\sأ)?\\s+{RoundNumberIntegerRegex})?|{ArabicPartOfItem}\\s+{RoundNumberIntegerRegex})(?=\\b)'
     FractionNounWithArticleRegex = f'(?<=\\b)((({AllIntRegex}(\\s|(\\s*-\\s*)|و\\s+)?)(({AllOrdinalRegex})|{NumberOrdinalRegex}|نصف|وربع|ربع|ونصف))|(الربع|النصف|نصف|))(?=\\b)'
-    FractionPrepositionRegex = f'(?<!{BaseNumbers.CommonCurrencySymbol}\\s*)(?<=\\b)(?<numerator>({AllIntRegex})|((?<![\\.,])\\d+))\\s+(فوق|على|في|جزء|من|أجزاء من|اجزاء من|جزء من)\\s+(?<denominator>({AllIntRegex})|(\\d+)(?![\\.,]))(?=\\b)'
-    FractionPrepositionWithinPercentModeRegex = f'(?<!{BaseNumbers.CommonCurrencySymbol}\\s*)(?<=\\b)(?<numerator>({AllIntRegex})|((?<![\\.,])\\d+))\\s+على\\s+(?<denominator>({AllIntRegex})|(\\d+)(?![\\.,]))(?=\\b)'
+    FractionPrepositionRegex = f'(?<!{BaseNumbers.CommonCurrencySymbol}\\s*)(?<=\\b)(?<numerator>({AllIntRegex})|((?<![.,])\\d+))\\s+(فوق|على|في|جزء|من|أجزاء من|اجزاء من|جزء من)\\s+(?<denominator>({AllIntRegex})|(\\d+)(?![.,]))(?=\\b)'
+    FractionPrepositionWithinPercentModeRegex = f'(?<!{BaseNumbers.CommonCurrencySymbol}\\s*)(?<=\\b)(?<numerator>({AllIntRegex})|((?<![.,])\\d+))\\s+على\\s+(?<denominator>({AllIntRegex})|(\\d+)(?![.,]))(?=\\b)'
     FractionWithOrdinalPrefix = f'({AllOrdinalRegex})(?=\\s*({FractionOrdinalPrefix}))'
     FractionWithPartOfPrefix = f'((جزء من)\\s+)({AllIntRegexWithLocks})'
     FractionMultiplierRegex = f'(?<fracMultiplier>\\s+{ArabicAndRegex}\\s(أ|واحد|{TwoToNineIntegerRegex})\\s+({ArabicPartOfItem}))'
@@ -64,19 +64,19 @@ class ArabicNumeric:
     RoundMultiplierRegex = f'\\s*\\b({RoundMultiplierWithFraction}|(?<multiplier>(?:مائة|ألف|مئات|الآلاف))$)'
     AllPointRegex = f'((\\s+{ZeroToNineIntegerRegex})+|(\\s+{SeparaIntRegex}))'
     AllFloatRegex = f'{AllIntRegex}(\\s+(نقطة|جزء|جزء من|فاصلة|نقاط|فاصل)){AllPointRegex}'
-    DoubleWithMultiplierRegex = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))\\d+\\u202A?[\\.,]\\u202A?\\d+\\s*{BaseNumbers.NumberMultiplierRegex}(?=\\b)'
-    DoubleExponentialNotationRegex = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))(\\d+(\\u202A?[\\.,]\\u202A?\\d+)?)e([+-]*[\\u0660-\\u0669]\\d*)(?=\\b)'
-    DoubleCaretExponentialNotationRegex = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))(\\d+(\\u202A?[\\.,]\\u202A?\\d+)?)[+-]*\\^([+-]*[\\u0660-\\u0669]([\\.,])?\\d*)(?=\\b)'
+    DoubleWithMultiplierRegex = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[.,])))\\d+\\u202A?[.,]\\u202A?\\d+\\s*{BaseNumbers.NumberMultiplierRegex}(?=\\b)'
+    DoubleExponentialNotationRegex = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[.,])))(\\d+(\\u202A?[.,]\\u202A?\\d+)?)e([+-]*[\\u0660-\\u0669]\\d*)(?=\\b)'
+    DoubleCaretExponentialNotationRegex = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[.,])))(\\d+(\\u202A?[.,]\\u202A?\\d+)?)[+-]*\\^([+-]*[\\u0660-\\u0669]([.,])?\\d*)(?=\\b)'
 
     def DoubleDecimalPointRegex(placeholder):
-        return f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))((?<!\\d.)(\\d+\\u202A?[\\.,٬،٫]\\u202A?\\d+))(?!([\\.,]\\d+))(?={placeholder})'
+        return f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[.,])))((?<!\\d.)(\\d+\\u202A?[.,٬،٫]\\u202A?\\d+))(?!([.,]\\d+))(?={placeholder})'
 
     def DoubleWithoutIntegralRegex(placeholder):
-        return f'(?<=\\s|^)(?<!(\\d+))\\u202A?[\\.,]\\u202A?\\d+(?!([\\.,]\\d+))(?={placeholder})'
-    DoubleWithRoundNumber = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))\\d+\\u202A?[\\.,]\\u202A?\\d+\\s+{RoundNumberIntegerRegex}(?=\\b)'
+        return f'(?<=\\s|^)(?<!(\\d+))\\u202A?[.,]\\u202A?\\d+(?!([.,]\\d+))(?={placeholder})'
+    DoubleWithRoundNumber = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[.,])))\\d+\\u202A?[.,]\\u202A?\\d+\\s+{RoundNumberIntegerRegex}(?=\\b)'
 
     def DoubleWithThousandMarkRegex(placeholder):
-        return f'(((?<!\\d+\\s*)-\\s*)|((?<=\\b)(?<!\\d+\\.|\\d+,|\\d+)))\\d{{1,3}}(\\u202A?[٬،]\\u202A?\\d{{3}})+\\u202A?[\\.,،٬٫]\\u202A?\\d+(?={placeholder})'
+        return f'(((?<!\\d+\\s*)-\\s*)|((?<=\\b)(?<!\\d+\\.|\\d+,|\\d+)))\\d{{1,3}}(\\u202A?[٬،]\\u202A?\\d{{3}})+\\u202A?[.,،٬٫]\\u202A?\\d+(?={placeholder})'
     DoubleAllFloatRegex = f'((?<=\\b){AllFloatRegex}(?=\\b))'
     ConnectorRegex = f'(?<spacer>و)'
     NumberWithSuffixPercentage = f'((?<!(٪|%))({BaseNumbers.NumberReplaceToken})(\\s*)((٪|%)(?!{BaseNumbers.NumberReplaceToken})|(بالمائة|في المئة|بالمئة)))'

--- a/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
@@ -69,14 +69,14 @@ class ArabicNumeric:
     DoubleCaretExponentialNotationRegex = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))(\\d+(\\u202A?[\\.,]\\u202A?\\d+)?)[+-]*\\^([+-]*[\\u0660-\\u0669]([\\.,])?\\d*)(?=\\b)'
 
     def DoubleDecimalPointRegex(placeholder):
-        return f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))((?<!\\d.)(\\d+\\u202A?[\\.,]\\u202A?\\d+))(?!([\\.,]\\d+))(?={placeholder})'
+        return f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))((?<!\\d.)(\\d+\\u202A?[\\.,٬،٫]\\u202A?\\d+))(?!([\\.,]\\d+))(?={placeholder})'
 
     def DoubleWithoutIntegralRegex(placeholder):
         return f'(?<=\\s|^)(?<!(\\d+))\\u202A?[\\.,]\\u202A?\\d+(?!([\\.,]\\d+))(?={placeholder})'
     DoubleWithRoundNumber = f'(((?<!\\d+\\s*)([-]\\s*)?)|((?<=\\b)(?<!\\d+[\\.,])))\\d+\\u202A?[\\.,]\\u202A?\\d+\\s+{RoundNumberIntegerRegex}(?=\\b)'
 
     def DoubleWithThousandMarkRegex(placeholder):
-        return f'(((?<!\\d+\\s*)-\\s*)|((?<=\\b)(?<!\\d+\\.|\\d+,)))\\d{{1,3}}(\\u202A?[،]\\u202A?\\d{{3}})+\\u202A?[\\.,]\\u202A?\\d+(?={placeholder})'
+        return f'(((?<!\\d+\\s*)-\\s*)|((?<=\\b)(?<!\\d+\\.|\\d+,|\\d+)))\\d{{1,3}}(\\u202A?[٬،]\\u202A?\\d{{3}})+\\u202A?[\\.,،٬٫]\\u202A?\\d+(?={placeholder})'
     DoubleAllFloatRegex = f'((?<=\\b){AllFloatRegex}(?=\\b))'
     ConnectorRegex = f'(?<spacer>و)'
     NumberWithSuffixPercentage = f'((?<!(٪|%))({BaseNumbers.NumberReplaceToken})(\\s*)((٪|%)(?!{BaseNumbers.NumberReplaceToken})|(بالمائة|في المئة|بالمئة)))'
@@ -113,9 +113,10 @@ class ArabicNumeric:
     DecimalSeparatorChar = '.'
     FractionMarkerToken = 'أكثر'
     NonDecimalSeparatorChar = ','
+    AlternateDecimalSeparatorChar = '٫'
     HalfADozenText = 'ستة'
     WordSeparatorToken = 'و'
-    WrittenDecimalSeparatorTexts = [r'فاصلة', r'فاصل', r'نقاط', r'نقطة']
+    WrittenDecimalSeparatorTexts = [r'فاصلة', r'فاصل', r'نقاط', r'نقطة', r'٫']
     WrittenGroupSeparatorTexts = [r'punto']
     WrittenIntegerSeparatorTexts = [r'و']
     WrittenFractionSeparatorTexts = [r'و']

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.25a0"
+VERSION = "1.1.25"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.22"
+VERSION = "1.1.23a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.23a0"
+VERSION = "1.1.23a1"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.23a0"
+VERSION = "1.1.23a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.22"
+VERSION = "1.1.23a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.25a0"
+VERSION = "1.1.25"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.25a0'
+VERSION = '1.1.25'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.25a0',
-    'recognizers-text-number-genesys==1.1.25a0',
-    'recognizers-text-number-with-unit-genesys==1.1.25a0',
-    'recognizers-text-date-time-genesys==1.1.25a0',
-    'recognizers-text-sequence-genesys==1.1.25a0',
-    'recognizers-text-choice-genesys==1.1.25a0',
-    'datatypes_timex_expression_genesys==1.1.25a0'
+    'recognizers-text-genesys==1.1.25',
+    'recognizers-text-number-genesys==1.1.25',
+    'recognizers-text-number-with-unit-genesys==1.1.25',
+    'recognizers-text-date-time-genesys==1.1.25',
+    'recognizers-text-sequence-genesys==1.1.25',
+    'recognizers-text-choice-genesys==1.1.25',
+    'datatypes_timex_expression_genesys==1.1.25'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.23a0'
+VERSION = '1.1.23a1'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.23a0',
-    'recognizers-text-number-genesys==1.1.23a0',
-    'recognizers-text-number-with-unit-genesys==1.1.23a0',
-    'recognizers-text-date-time-genesys==1.1.23a0',
-    'recognizers-text-sequence-genesys==1.1.23a0',
-    'recognizers-text-choice-genesys==1.1.23a0',
-    'datatypes_timex_expression_genesys==1.1.23a0'
+    'recognizers-text-genesys==1.1.23a1',
+    'recognizers-text-number-genesys==1.1.23a1',
+    'recognizers-text-number-with-unit-genesys==1.1.23a1',
+    'recognizers-text-date-time-genesys==1.1.23a1',
+    'recognizers-text-sequence-genesys==1.1.23a1',
+    'recognizers-text-choice-genesys==1.1.23a1',
+    'datatypes_timex_expression_genesys==1.1.23a1'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.22'
+VERSION = '1.1.23a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.22',
-    'recognizers-text-number-genesys==1.1.22',
-    'recognizers-text-number-with-unit-genesys==1.1.22',
-    'recognizers-text-date-time-genesys==1.1.22',
-    'recognizers-text-sequence-genesys==1.1.22',
-    'recognizers-text-choice-genesys==1.1.22',
-    'datatypes_timex_expression_genesys==1.1.22'
+    'recognizers-text-genesys==1.1.23a0',
+    'recognizers-text-number-genesys==1.1.23a0',
+    'recognizers-text-number-with-unit-genesys==1.1.23a0',
+    'recognizers-text-date-time-genesys==1.1.23a0',
+    'recognizers-text-sequence-genesys==1.1.23a0',
+    'recognizers-text-choice-genesys==1.1.23a0',
+    'datatypes_timex_expression_genesys==1.1.23a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.22"
+VERSION = "1.1.23a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.23a0"
+VERSION = "1.1.23a1"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.25a0"
+VERSION = "1.1.25"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -361,7 +361,7 @@
   {
     "Input": "عدد السكان في الهند ١،٢٣٤،٥٦٧",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, python",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "١،٢٣٤،٥٦٧",
@@ -1447,7 +1447,7 @@
   {
     "Input": "سالب واحد على ٢٠",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, python",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "سالب واحد على ٢٠",
@@ -1780,7 +1780,7 @@
   {
     "Input": "الكسر الصحيح ٢٠٠٠ على ٣",
     "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, python",
+    "NotSupportedByDesign": "javascript, java",
     "Results": [
       {
         "Text": "٢٠٠٠ على ٣",
@@ -5616,6 +5616,70 @@
         },
         "Start": 16,
         "End": 20
+      }
+    ]
+  },
+  {
+    "Input": "هل أستطيع الحصول على ۲٬٣۵٩ درهم",
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "۲٬٣۵٩",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2359"
+        },
+        "Start": 21,
+        "End": 25
+      }
+    ]
+  },
+  {
+    "Input": "۸٩٫۷۰ هو عدد الأشخاص في إسبانيا",
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "۸٩٫۷۰",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "decimal",
+          "value": "89.7"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "يبلغ رصيد حسابي البنكي حوالي ۴۵۳٬۲۸۰٬۷۱۶",
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "۴۵۳٬۲۸۰٬۷۱۶",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "453280716"
+        },
+        "Start": 29,
+        "End": 39
+      }
+    ]
+  },
+  {
+    "Input": "في اليوم ١٬٠٠٠٫٠٥ سيحدث شيء ما.",
+    "NotSupportedByDesign": "javascript, java",
+    "Results": [
+      {
+        "Text": "١٬٠٠٠٫٠٥",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "decimal",
+          "value": "1000.05"
+        },
+        "Start": 9,
+        "End": 16
       }
     ]
   }


### PR DESCRIPTION
Fix for Arabic Eastern digits (١, ٢, ٣, ٤, ٥, ٦, ٧, ٨, ٩, ٠) not resolving correctly.

Issue wasn't with digits themselves, more so with the way they were being written. Special arabic separators are used in order to distinguish decimals and thousands as below

- ```٬``` - Arabic thousand separator
- ```٫``` - Arabic decimal separator

These entries were not present in regex files, causing the following examples to fail:

- ```١٬٠٠٠٫٠٥``` - 1,000.05
- ```۴۵۳٬۲۸۰٬۷۱۶``` - 453,280,716