### PR TITLE
[NLU-3225_2] Fix for incorrect Portuguese date resolution

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.24a0'
+VERSION = '1.1.24'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.22'
+VERSION = '1.1.24a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.22'
+VERSION = '1.1.24a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.24a0'
+VERSION = '1.1.24'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/portuguese_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/portuguese_date_time.py
@@ -106,7 +106,7 @@ class PortugueseDateTime:
     DateExtractor6 = f'(?<=\\b(em|no|o)\\s+){MonthNumRegex}[\\-\\.]{DayRegex}{BaseDateTime.CheckDecimalRegex}\\b'
     DateExtractor7 = f'\\b({WeekDayRegex}(\\s+|\\s*,\\s*))?{MonthNumRegex}\\s*/\\s*{DayRegex}((\\s+|\\s*(,|de)\\s*){DateYearRegex})?{BaseDateTime.CheckDecimalRegex}\\b'
     DateExtractor8 = f'(?<=\\b(em|no|o)\\s+){DayRegex}[\\\\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}\\b'
-    DateExtractor9 = f'\\b({WeekDayRegex}(\\s+|\\s*,\\s*))?(dia\\s)?{DayRegex}\\s*(/|do)\\s*{MonthNumRegex}((\\s+|\\s*(,|de)\\s*){DateYearRegex})?{BaseDateTime.CheckDecimalRegex}\\b'
+    DateExtractor9 = f'\\b({WeekDayRegex}(\\s+|\\s*,\\s*))?(dia\\s)?{DayRegex}\\s*(/|do)\\s*{MonthNumRegex}((\\s+|\\s*(,|de)\\s*|\\s*[/\\\\\\-\\.]){DateYearRegex})?{BaseDateTime.CheckDecimalRegex}\\b'
     DateExtractor10 = f'\\b({WeekDayRegex}(\\s+|\\s*,\\s*))?({YearRegex}\\s*[/\\\\\\-\\.]\\s*({MonthNumRegex}|{MonthRegex})\\s*[/\\\\\\-\\.]\\s*{DayRegex}|{MonthRegex}\\s*[/\\\\\\-\\.]\\s*{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*{DayRegex}|{DayRegex}\\s*[/\\\\\\-\\.]\\s*{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*{MonthRegex})(?!\\s*[/\\\\\\-\\.:]\\s*\\d+)'
     DateExtractor11 = f'(?<=\\b(dia)\\s+){DayRegex}'
     HourNumRegex = f'\\b(?<hournum>zero|uma|duas|tr[êe]s|[qc]uatro|cinco|seis|sete|oito|nove|dez|onze|doze)\\b'

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.22'
+VERSION = '1.1.24a0'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.24a0'
+VERSION = '1.1.24'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.22"
+VERSION = "1.1.24a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.24a0"
+VERSION = "1.1.24"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.24a0"
+VERSION = "1.1.24"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.22"
+VERSION = "1.1.24a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.22"
+VERSION = "1.1.24a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.24a0"
+VERSION = "1.1.24"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.22'
+VERSION = '1.1.24a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.22',
-    'recognizers-text-number-genesys==1.1.22',
-    'recognizers-text-number-with-unit-genesys==1.1.22',
-    'recognizers-text-date-time-genesys==1.1.22',
-    'recognizers-text-sequence-genesys==1.1.22',
-    'recognizers-text-choice-genesys==1.1.22',
-    'datatypes_timex_expression_genesys==1.1.22'
+    'recognizers-text-genesys==1.1.24a0',
+    'recognizers-text-number-genesys==1.1.24a0',
+    'recognizers-text-number-with-unit-genesys==1.1.24a0',
+    'recognizers-text-date-time-genesys==1.1.24a0',
+    'recognizers-text-sequence-genesys==1.1.24a0',
+    'recognizers-text-choice-genesys==1.1.24a0',
+    'datatypes_timex_expression_genesys==1.1.24a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.24a0'
+VERSION = '1.1.24'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.24a0',
-    'recognizers-text-number-genesys==1.1.24a0',
-    'recognizers-text-number-with-unit-genesys==1.1.24a0',
-    'recognizers-text-date-time-genesys==1.1.24a0',
-    'recognizers-text-sequence-genesys==1.1.24a0',
-    'recognizers-text-choice-genesys==1.1.24a0',
-    'datatypes_timex_expression_genesys==1.1.24a0'
+    'recognizers-text-genesys==1.1.24',
+    'recognizers-text-number-genesys==1.1.24',
+    'recognizers-text-number-with-unit-genesys==1.1.24',
+    'recognizers-text-date-time-genesys==1.1.24',
+    'recognizers-text-sequence-genesys==1.1.24',
+    'recognizers-text-choice-genesys==1.1.24',
+    'datatypes_timex_expression_genesys==1.1.24'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.24a0"
+VERSION = "1.1.24"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.22"
+VERSION = "1.1.24a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/DateTime/Portuguese/DateExtractor.json
+++ b/Specs/DateTime/Portuguese/DateExtractor.json
@@ -738,5 +738,17 @@
         "Length": 12
       }
     ]
+  },
+  {
+    "Input": "minha compra feita no dia 7/7/2020",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "dia 7/7/2020",
+        "Type": "date",
+        "Start": 22,
+        "Length": 12
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Portuguese/DateParser.json
+++ b/Specs/DateTime/Portuguese/DateParser.json
@@ -1599,5 +1599,29 @@
         "Length": 11
       }
     ]
+  },
+  {
+    "Input": "minha compra feita no dia 7/7/2020",
+    "Context": {
+      "ReferenceDateTime": "2024-11-17T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "dia 7/7/2020",
+        "Type": "date",
+        "Value": {
+          "Timex": "2020-07-07",
+          "FutureResolution": {
+            "date": "2020-07-07"
+          },
+          "PastResolution": {
+            "date": "2020-07-07"
+          }
+        },
+        "Start": 22,
+        "Length": 12
+      }
+    ]
   }
 ]


### PR DESCRIPTION
```Eu preciso do reembolso da minha compra feita no dia 7/7/2020``` was resolving to ```2024-07-07``` due to ```dia``` being added to ```DateExtractor9``` regex, essentially changing which regex was capturing this utterance. This meant that day and month were being resolved but not the year itself due to missing backslashes in the regex.

This PR fixes this and adds some tests