### PR TITLE
[NLU-4161] - Arabic Number: Incorrect start index

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.30a1'
+VERSION = '1.1.30'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.29'
+VERSION = '1.1.30a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.30a0'
+VERSION = '1.1.30a1'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.30a0'
+VERSION = '1.1.30a1'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.30a1'
+VERSION = '1.1.30'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.29'
+VERSION = '1.1.30a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.30a1'
+VERSION = '1.1.30'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.29'
+VERSION = '1.1.30a0'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.30a0'
+VERSION = '1.1.30a1'
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys',
             'recognizers-text-number-with-unit-genesys', 'regex', 'datedelta', 'python-dateutil']
 

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.29"
+VERSION = "1.1.30a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.30a0"
+VERSION = "1.1.30a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.30a1"
+VERSION = "1.1.30"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
@@ -75,7 +75,7 @@ class BaseNumberExtractor(Extractor):
                         if match is not None:
                             start = match.start()
                             length = length + match.end() - match.start()
-                            substr = source[start:start + length].strip()
+                            substr = source[start:start + length]
 
                     if src_match is not None:
                         value = ExtractResult()

--- a/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
@@ -63,7 +63,7 @@ class BaseNumberExtractor(Extractor):
                 if i + 1 == len(source) or not matched[i + 1]:
                     start = last + 1
                     length = i - last
-                    substr = source[start:start + length].strip()
+                    substr = source[start:start + length]
                     src_match = next((x for x in iter(match_source) if (
                         x.start() == start and (
                             x.end() - x.start()) == length)), None)

--- a/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
@@ -180,7 +180,7 @@ class BasePercentageExtractor(Extractor):
                 if (i + 1) == len(source) or not matched[i + 1]:
                     start = last + 1
                     length = i - last
-                    substr = source[start:start + length].strip()
+                    substr = source[start:start + length]
                     value = ExtractResult()
                     value.start = start
                     value.length = length

--- a/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/arabic_numeric.py
@@ -26,8 +26,8 @@ class ArabicNumeric:
     AnIntRegex = f'(واحد|أحد)(?=\\s)'
     TenToNineteenIntegerRegex = f'(?:((ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنان|اثنين|اثتنين|اثنتان|إثنان|إثنتان|إثنين|إثتنين|إثنتان|ستة|أحد|أربعة|إثني|اثني)\\s(عشر|عشرة)))'
     TensNumberIntegerRegex = f'(عشرة|عشرون|ثلاثون|أربعون|خمسون|ستون|سبعون|ثمانون|تسعين|وعشرين|و عشرين|وثلاثين|و ثلاثين|وأربعين|و أربعين|وخمسين|و خمسين|وستين|وستين|وسبعين|و سبعين|وثمانين|و ثمانين|وتسعين|وتسعين|وعشرون|ثلاثون|وأربعون|و أربعون|وخمسون|و خمسون|وستون|و ستون|وسبعون|و سبعون|وثمانون|و ثمانون|وتسعون|و تسعون|عشرين|ثلاثين|أربعين|خمسين|ستين|سبعين|ثمانين|تسعون|العشرون:?)'
-    SeparaIntRegex = f'(?:((({RoundNumberIntegerRegex}\\s{RoundNumberIntegerRegex})|{TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(((و)?)\\s+(و)?|\\s*-\\s*){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\\s+{RoundNumberIntegerRegex})*))|(((\\s+{RoundNumberIntegerRegex})+))'
-    AllIntRegex = f'(?:({SeparaIntRegex})((\\s*(و)\\s*)({SeparaIntRegex})(\\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\\s+(و)?|\\s*-\\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?(\\s+{RoundNumberIntegerRegex})+)\\s+(و)?)*{SeparaIntRegex})'
+    SeparaIntRegex = f'(?:((({RoundNumberIntegerRegex}\\s{RoundNumberIntegerRegex})|{TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(((و)?)\\s+(و)?|\\s*-\\s*){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\\s+{RoundNumberIntegerRegex})*))|((({RoundNumberIntegerRegex})+))'
+    AllIntRegex = f'(?:({SeparaIntRegex})((\\s*(و)\\s*)({SeparaIntRegex})(\\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\\s+(و)?|\\s*-\\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?({RoundNumberIntegerRegex})+)\\s+(و)?)*{SeparaIntRegex})'
     PlaceHolderPureNumber = f'\\b'
     PlaceHolderDefault = f'\\D|\\b'
 

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.30a0"
+VERSION = "1.1.30a1"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.30a1"
+VERSION = "1.1.30"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.29"
+VERSION = "1.1.30a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.29"
+VERSION = "1.1.30a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.30a1"
+VERSION = "1.1.30"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.30a0"
+VERSION = "1.1.30a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.30a0'
+VERSION = '1.1.30a1'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.30a0',
-    'recognizers-text-number-genesys==1.1.30a0',
-    'recognizers-text-number-with-unit-genesys==1.1.30a0',
-    'recognizers-text-date-time-genesys==1.1.30a0',
-    'recognizers-text-sequence-genesys==1.1.30a0',
-    'recognizers-text-choice-genesys==1.1.30a0',
-    'datatypes_timex_expression_genesys==1.1.30a0'
+    'recognizers-text-genesys==1.1.30a1',
+    'recognizers-text-number-genesys==1.1.30a1',
+    'recognizers-text-number-with-unit-genesys==1.1.30a1',
+    'recognizers-text-date-time-genesys==1.1.30a1',
+    'recognizers-text-sequence-genesys==1.1.30a1',
+    'recognizers-text-choice-genesys==1.1.30a1',
+    'datatypes_timex_expression_genesys==1.1.30a1'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.29'
+VERSION = '1.1.30a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.29',
-    'recognizers-text-number-genesys==1.1.29',
-    'recognizers-text-number-with-unit-genesys==1.1.29',
-    'recognizers-text-date-time-genesys==1.1.29',
-    'recognizers-text-sequence-genesys==1.1.29',
-    'recognizers-text-choice-genesys==1.1.29',
-    'datatypes_timex_expression_genesys==1.1.29'
+    'recognizers-text-genesys==1.1.30a0',
+    'recognizers-text-number-genesys==1.1.30a0',
+    'recognizers-text-number-with-unit-genesys==1.1.30a0',
+    'recognizers-text-date-time-genesys==1.1.30a0',
+    'recognizers-text-sequence-genesys==1.1.30a0',
+    'recognizers-text-choice-genesys==1.1.30a0',
+    'datatypes_timex_expression_genesys==1.1.30a0'
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -10,15 +10,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.30a1'
+VERSION = '1.1.30'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.30a1',
-    'recognizers-text-number-genesys==1.1.30a1',
-    'recognizers-text-number-with-unit-genesys==1.1.30a1',
-    'recognizers-text-date-time-genesys==1.1.30a1',
-    'recognizers-text-sequence-genesys==1.1.30a1',
-    'recognizers-text-choice-genesys==1.1.30a1',
-    'datatypes_timex_expression_genesys==1.1.30a1'
+    'recognizers-text-genesys==1.1.30',
+    'recognizers-text-number-genesys==1.1.30',
+    'recognizers-text-number-with-unit-genesys==1.1.30',
+    'recognizers-text-date-time-genesys==1.1.30',
+    'recognizers-text-sequence-genesys==1.1.30',
+    'recognizers-text-choice-genesys==1.1.30',
+    'datatypes_timex_expression_genesys==1.1.30'
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.30a0"
+VERSION = "1.1.30a1"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.30a1"
+VERSION = "1.1.30"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.29"
+VERSION = "1.1.30a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -4968,7 +4968,7 @@
           "subtype": "integer",
           "value": "1000"
         },
-        "Start": 28,
+        "Start": 29,
         "End": 31
       }
     ]
@@ -5032,7 +5032,7 @@
           "subtype": "integer",
           "value": "300"
         },
-        "Start": 4,
+        "Start": 5,
         "End": 12
       },
       {
@@ -5042,7 +5042,7 @@
           "subtype": "integer",
           "value": "501"
         },
-        "Start": 19,
+        "Start": 20,
         "End": 33
       }
     ]
@@ -5106,7 +5106,7 @@
           "subtype": "integer",
           "value": "1000000000"
         },
-        "Start": 28,
+        "Start": 29,
         "End": 33
       }
     ]
@@ -5122,7 +5122,7 @@
           "subtype": "integer",
           "value": "1000000000000"
         },
-        "Start": 18,
+        "Start": 19,
         "End": 25
       }
     ]
@@ -5154,7 +5154,7 @@
           "subtype": "integer",
           "value": "100"
         },
-        "Start": 15,
+        "Start": 16,
         "End": 18
       }
     ]
@@ -5170,7 +5170,7 @@
           "subtype": "integer",
           "value": "200"
         },
-        "Start": 25,
+        "Start": 26,
         "End": 30
       }
     ]
@@ -5186,7 +5186,7 @@
           "subtype": "integer",
           "value": "2000"
         },
-        "Start": 10,
+        "Start": 11,
         "End": 15
       }
     ]
@@ -5218,7 +5218,7 @@
           "subtype": "integer",
           "value": "100000"
         },
-        "Start": 4,
+        "Start": 5,
         "End": 12
       }
     ]
@@ -5266,7 +5266,7 @@
           "subtype": "integer",
           "value": "1000"
         },
-        "Start": 10,
+        "Start": 11,
         "End": 14
       },
       {
@@ -5276,7 +5276,7 @@
           "subtype": "integer",
           "value": "1000"
         },
-        "Start": 23,
+        "Start": 24,
         "End": 26
       }
     ]

--- a/Specs/NumberWithUnit/Arabic/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Arabic/CurrencyModel.json
@@ -172,13 +172,13 @@
     "Input": "لقد فزت للتو بألفي دولار!",
     "Results": [
       {
-        "Text": " بألفي دولار",
+        "Text": "بألفي دولار",
         "TypeName": "currency",
         "Resolution": {
           "value": "2000",
           "unit": "Dollar"
         },
-        "Start": 12,
+        "Start": 13,
         "End": 23
       }
     ]


### PR DESCRIPTION
There was a problem with the "start_index" attribute of the NLUEntity when resolving Arabic numbers. This attribute does not always reflect the exact position of the resolved entity within the input text. As a result, there is a discrepancy when comparing the "raw" value against the corresponding substring extracted using the start_index and end_index.

For example, for "انا ولدت في ألفين وتسعة" (I was born in two thousand and nine), the number entity for "2009" is being resolved correctly. However, the start index of the resolved entity is 11 instead of the expected value of 12. 

Fix involves removing logic which stripped any leading whitespace from the ```text``` attribute of ```ExtractResults``` as there was no known need for this logic to be present.

Also includes minor change to RoundNumberInteger regex in which the space before a "Round number" (100, 1000, 10000, etc) was being captured along with the RoundNumber, which is what caused the issue to occur. 