### PR TITLE
[NLU-4799] Number parser: fix for zero base with exponent

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.39'
+VERSION = '1.1.40'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.39'
+VERSION = '1.1.40'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.39'
+VERSION = '1.1.40'
 REQUIRES = [
     'recognizers-text-genesys',
     'recognizers-text-number-genesys',

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.39"
+VERSION = "1.1.40"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/recognizers_number/number/parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/parsers.py
@@ -435,7 +435,9 @@ class BaseNumberParser(Parser):
         for i in range(len(handle)):
             c = handle[i]
             if c in ['^', 'E']:
-                if negative:
+                if tmp == 0:
+                    call_stack.append(Decimal('0'))
+                elif negative:
                     call_stack.append(-tmp)
                 else:
                     call_stack.append(tmp)
@@ -464,7 +466,10 @@ class BaseNumberParser(Parser):
         result_value = 0
         a = Decimal(call_stack.pop(0))
         b = Decimal(call_stack.pop(0))
-        if exponent:
+
+        if a == Decimal('0'):
+            result_value = Decimal('0')
+        elif exponent:
             result_value = getcontext().multiply(a, getcontext().power(Decimal(10), b))
         else:
             result_value = getcontext().power(a, b)

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.39"
+VERSION = "1.1.40"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.39"
+VERSION = "1.1.40"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,15 +11,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.39'
+VERSION = '1.1.40'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.39',
-    'recognizers-text-number-genesys==1.1.39',
-    'recognizers-text-number-with-unit-genesys==1.1.39',
-    'recognizers-text-date-time-genesys==1.1.39',
-    'recognizers-text-sequence-genesys==1.1.39',
-    'recognizers-text-choice-genesys==1.1.39',
-    'datatypes_timex_expression_genesys==1.1.39',
+    'recognizers-text-genesys==1.1.40',
+    'recognizers-text-number-genesys==1.1.40',
+    'recognizers-text-number-with-unit-genesys==1.1.40',
+    'recognizers-text-date-time-genesys==1.1.40',
+    'recognizers-text-sequence-genesys==1.1.40',
+    'recognizers-text-choice-genesys==1.1.40',
+    'datatypes_timex_expression_genesys==1.1.40',
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.39"
+VERSION = "1.1.40"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/DateTime/French/DateTimeParser.json
+++ b/Specs/DateTime/French/DateTimeParser.json
@@ -2611,6 +2611,9 @@
   },
   {
     "Input": "une heure du matin",
+    "Context": {
+      "ReferenceDateTime": "2025-01-15T00:00:00"
+    },
     "NotSupported": "dotnet, javascript, java",
     "Results": [
       {

--- a/Specs/Number/Catalan/NumberModel.json
+++ b/Specs/Number/Catalan/NumberModel.json
@@ -233,5 +233,133 @@
         }
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Chinese/NumberModel.json
+++ b/Specs/Number/Chinese/NumberModel.json
@@ -5312,5 +5312,133 @@
         "End": 30
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Dutch/NumberModel.json
+++ b/Specs/Number/Dutch/NumberModel.json
@@ -2170,5 +2170,133 @@
         "End": 33
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -1264,6 +1264,134 @@
     ]
   },
   {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
     "Input": "1.2b",
     "Results": [
       {

--- a/Specs/Number/French/NumberModel.json
+++ b/Specs/Number/French/NumberModel.json
@@ -4506,5 +4506,133 @@
         "End": 31
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/German/NumberModel.json
+++ b/Specs/Number/German/NumberModel.json
@@ -1038,5 +1038,133 @@
         "End": 40
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Hindi/NumberModel.json
+++ b/Specs/Number/Hindi/NumberModel.json
@@ -3064,5 +3064,133 @@
         "End": 28
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Italian/NumberModel.json
+++ b/Specs/Number/Italian/NumberModel.json
@@ -2273,5 +2273,133 @@
         "End": 33
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Japanese/NumberModel.json
+++ b/Specs/Number/Japanese/NumberModel.json
@@ -13264,5 +13264,133 @@
         "End": 54
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Korean/NumberModel.json
+++ b/Specs/Number/Korean/NumberModel.json
@@ -4136,5 +4136,133 @@
     "Input": "오늘 내일",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Portuguese/NumberModel.json
+++ b/Specs/Number/Portuguese/NumberModel.json
@@ -2712,5 +2712,133 @@
         "End": 37
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Spanish/NumberModel.json
+++ b/Specs/Number/Spanish/NumberModel.json
@@ -3275,5 +3275,133 @@
   {
     "Input": "billons",
     "Results": []
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/SpanishMexican/NumberModel.json
+++ b/Specs/Number/SpanishMexican/NumberModel.json
@@ -166,5 +166,133 @@
         "End": 17
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Swedish/NumberModel.json
+++ b/Specs/Number/Swedish/NumberModel.json
@@ -2617,5 +2617,133 @@
         "End": 27
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/Turkish/NumberModel.json
+++ b/Specs/Number/Turkish/NumberModel.json
@@ -2150,5 +2150,133 @@
         }
       }
     ]
+  },
+  {
+    "Input": "-0e63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0e49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0e-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0e-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0e-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0e-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "-0^63",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^63",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0^49",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^49",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "0^-23",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "0^-23",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "-0^-17",
+    "NotSupported": "dotnet, javascript, java",
+    "Results": [
+      {
+        "Text": "-0^-17",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "power",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixing a bug in the Number parser where numbers with a zero base and an exponent, e.g. "-0e63", were not resolved correctly. Previously, these numbers would lose their zero value during exponent calculation, resulting in invalid exponential notation in the output:

```python
{
    "text": "-0e63",
    "type_name": "number",
    "resolution": {"value": "E+49"},  # Invalid exponential notation
    "start": 0,
    "end": 4
}
```

This PR adds handling for the zero base numbers to ensure they are resolved correctly to "0" as expected.