### PR TITLE
Nlu 5375 builtin:number match phone number as a number

### DIFF
--- a/Python/libraries/recognizers-number/recognizers_number/resources/english_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/english_numeric.py
@@ -310,7 +310,8 @@ class EnglishNumeric:
             ("t", 1000000000000),
         ]
     )
-    AmbiguityFiltersDict = dict([("\\bone\\b", "\\b(the|this|that|which)\\s+(one)\\b")])
+    AmbiguityFiltersDict = dict([("\\bone\\b", "\\b(the|this|that|which)\\s+(one)\\b"),
+                                 ("^0[678]\\d{8}$", "^0[678]\\d{8}$")])
     RelativeReferenceOffsetMap = dict(
         [
             ("last", "0"),


### PR DESCRIPTION
This pr is to stop phone numbers resolving as an amount.
I've added a regex which checks for the phone number pattern from the botflow linked in the ticket and excludes it from being returned. This is just an idea as i feel like this will just lead to other number use cases being excluded.
Does anyone have any suggestions on ways to exclude a phone number pattern like this without any other implications?
[NLU-5375](https://inindca.atlassian.net/browse/NLU-5375)

[NLU-5375]: https://inindca.atlassian.net/browse/NLU-5375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ