### PR TITLE
[NLU-5840] - Fix "con" decimal separator for amountOfMoney without currency prefix in Spanish

### DIFF
--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.47a1'
+VERSION = '1.1.47a2'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.47a3'
+VERSION = '1.1.47'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.46'
+VERSION = '1.1.47a0'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.47a2'
+VERSION = '1.1.47a3'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/datatypes-timex-expression/setup.py
+++ b/Python/libraries/datatypes-timex-expression/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'datatypes_timex_expression_genesys'
-VERSION = '1.1.47a0'
+VERSION = '1.1.47a1'
 REQUIRES = []
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.47a3'
+VERSION = '1.1.47'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.47a2'
+VERSION = '1.1.47a3'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.47a0'
+VERSION = '1.1.47a1'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.47a1'
+VERSION = '1.1.47a2'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-choice-genesys'
-VERSION = '1.1.46'
+VERSION = '1.1.47a0'
 REQUIRES = ['recognizers-text-genesys', 'regex', 'grapheme']
 
 setup(

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.47a2'
+VERSION = '1.1.47a3'
 REQUIRES = [
     'recognizers-text-genesys',
     'recognizers-text-number-genesys',

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.46'
+VERSION = '1.1.47a0'
 REQUIRES = [
     'recognizers-text-genesys',
     'recognizers-text-number-genesys',

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.47a1'
+VERSION = '1.1.47a2'
 REQUIRES = [
     'recognizers-text-genesys',
     'recognizers-text-number-genesys',

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.47a3'
+VERSION = '1.1.47'
 REQUIRES = [
     'recognizers-text-genesys',
     'recognizers-text-number-genesys',

--- a/Python/libraries/recognizers-date-time/setup.py
+++ b/Python/libraries/recognizers-date-time/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = 'recognizers-text-date-time-genesys'
-VERSION = '1.1.47a0'
+VERSION = '1.1.47a1'
 REQUIRES = [
     'recognizers-text-genesys',
     'recognizers-text-number-genesys',

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
@@ -2,7 +2,6 @@
 #  Licensed under the MIT License.
 
 from collections import namedtuple
-from copy import deepcopy
 from typing import Dict, List, Match, Pattern, Set
 
 import regex
@@ -15,7 +14,7 @@ from recognizers_text.matcher.number_with_unit_tokenizer import NumberWithUnitTo
 from recognizers_text.matcher.string_matcher import StringMatcher
 from recognizers_text.utilities import RegExpUtility
 
-from .constants import *
+from .constants import BaseUnits, Constants
 from .utilities import Token
 
 
@@ -123,7 +122,6 @@ class NumberWithUnitExtractor(Extractor):
         unit_is_prefix = []
 
         mapping_prefix: Dict[float, PrefixUnitResult] = dict()
-        matched = [False] * len(source)
         result = []
         prefix_matched = False
         prefix_match: List[MatchResult] = sorted(self.prefix_matcher.find(source), key=lambda o: o.start)
@@ -242,8 +240,6 @@ class NumberWithUnitExtractor(Extractor):
                             if non_unit_match is None:
                                 non_unit_match = list(self.config.non_unit_regex.finditer(source))
                             for time in non_unit_match:
-                                trimmed_source = source.lower()
-                                index = trimmed_source.index(time.group())
                                 if er.start >= time.start() and er.start + er.length <= time.start() + len(
                                     time.group()
                                 ):
@@ -274,7 +270,7 @@ class NumberWithUnitExtractor(Extractor):
             if non_unit_match is None:
                 try:
                     non_unit_match = list(self.config.non_unit_regex.match(source))
-                except:
+                except Exception:
                     non_unit_match = []
 
             self._extract_separate_units(source, result, non_unit_match)
@@ -302,7 +298,6 @@ class NumberWithUnitExtractor(Extractor):
     def _extract_separate_units(
         self, source: str, num_depend_source: List[ExtractResult], non_unit_matches
     ) -> List[ExtractResult]:
-        result = deepcopy(num_depend_source)
         match_result: List[bool] = [False] * len(source)
         for ex_result in num_depend_source:
             start = ex_result.start
@@ -642,6 +637,22 @@ class BaseMergedUnitExtractor(Extractor):
 
     def __merge_pure_number(self, source: str, ers: List[ExtractResult]) -> List[ExtractResult]:
         num_ers = self.config.unit_num_extractor.extract(source)
+
+        # When no currency units were extracted but there are multiple numbers
+        # separated by a compound connector (e.g., "26663 con 11" in Spanish),
+        # merge them into a compound currency extraction so the parser can
+        # resolve them as a single decimal value (e.g., 26663.11).
+        if not ers and len(num_ers) >= 2:
+            ers = self.__merge_connector_numbers(source, num_ers, ers)
+            if ers:
+                return ers
+
+        # Check for pure numbers that precede an existing currency extraction
+        # and are connected by a compound connector (e.g., "26663 con 11 pesos").
+        # In this case, merge the preceding number into the currency extraction
+        # as the integer portion.
+        ers = self.__merge_preceding_number(source, num_ers, ers)
+
         unit_numbers = []
         i = j = 0
         while i < len(num_ers):
@@ -688,3 +699,153 @@ class BaseMergedUnitExtractor(Extractor):
         ers = sorted(ers, key=lambda e: e.start)
 
         return ers
+
+    def __merge_preceding_number(
+        self, source: str, num_ers: List[ExtractResult], ers: List[ExtractResult]
+    ) -> List[ExtractResult]:
+        """Merge a pure number preceding a currency extraction via compound connector.
+
+        Handles patterns like "26663 con 11 pesos" where "11 pesos" is already
+        extracted as a currency entity, and "26663" precedes it connected by "con".
+        The result should merge 26663 as the integer part of the currency amount.
+        """
+        if not ers or not num_ers:
+            return ers
+
+        modified_ers = list(ers)
+        for idx, er in enumerate(ers):
+            if er.type != Constants.SYS_UNIT_CURRENCY:
+                continue
+
+            # Find a pure number that ends before this extraction starts
+            # and is separated only by a compound connector
+            for num in num_ers:
+                # The number must end before the currency extraction starts
+                num_end = num.start + num.length
+                if num_end >= er.start:
+                    continue
+
+                # Must be an integer
+                if not (isinstance(num.data, str) and num.data.startswith("Integer")):
+                    continue
+
+                # Ensure this number is not already covered by another extraction
+                is_covered = False
+                for other_er in ers:
+                    if other_er.start <= num.start and other_er.start + other_er.length >= num_end:
+                        is_covered = True
+                        break
+                if is_covered:
+                    continue
+
+                # Check if the text between the number and extraction is a connector
+                middle_str = source[num_end : er.start].strip().lower()
+                if not middle_str:
+                    continue
+
+                match = self.config.compound_unit_connector_regex.match(middle_str)
+                if match is None:
+                    continue
+                splitted_match = match.string.split(" ")
+                if not (match.pos == 0 and len(splitted_match[0]) == len(middle_str)):
+                    continue
+
+                # Merge: expand the extraction to include the preceding number
+                # and update data to be a compound list
+                int_er = self.__build_integer_er(num)
+                new_er = ExtractResult()
+                new_er.start = num.start
+                new_er.length = (er.start + er.length) - num.start
+                new_er.text = source[new_er.start : new_er.start + new_er.length]
+                new_er.type = Constants.SYS_UNIT_CURRENCY
+                new_er.data = [int_er, er]
+
+                modified_ers[idx] = new_er
+                break  # Only merge one preceding number per extraction
+
+        return modified_ers
+
+    def __merge_connector_numbers(
+        self, source: str, num_ers: List[ExtractResult], ers: List[ExtractResult]
+    ) -> List[ExtractResult]:
+        """Merge consecutive pure numbers separated by compound unit connectors.
+
+        Handles patterns like "26663 con 11" where no currency prefix/suffix
+        is present but the connector word indicates a decimal relationship
+        between the integer and fractional parts.
+        """
+        i = 0
+        while i < len(num_ers) - 1:
+            current = num_ers[i]
+            next_num = num_ers[i + 1]
+
+            # Check if current number data starts with "Integer"
+            if not (isinstance(current.data, str) and current.data.startswith("Integer")):
+                i += 1
+                continue
+
+            middle_begin = current.start + current.length
+            middle_end = next_num.start
+            middle_str = source[middle_begin:middle_end].strip().lower()
+
+            if not middle_str:
+                i += 1
+                continue
+
+            match = self.config.compound_unit_connector_regex.match(middle_str)
+            if match is not None:
+                splitted_match = match.string.split(" ")
+            else:
+                i += 1
+                continue
+
+            if match and match.pos == 0 and len(splitted_match[0]) == len(middle_str):
+                # Create a compound currency extraction spanning both numbers
+                # and the connector. Store both numbers as a list in data so
+                # the downstream grouping treats this as a compound unit with
+                # an integer portion and a fractional portion.
+                int_er = self.__build_integer_er(current)
+
+                frac_er = ExtractResult()
+                frac_er.start = next_num.start
+                frac_er.length = next_num.length
+                frac_er.text = next_num.text
+                frac_er.type = Constants.SYS_NUM
+                frac_er.data = next_num.data
+
+                er = ExtractResult()
+                er.start = current.start
+                er.length = (next_num.start + next_num.length) - current.start
+                er.text = source[er.start : er.start + er.length]
+                er.type = Constants.SYS_UNIT_CURRENCY
+                er.data = [int_er, frac_er]
+
+                ers.append(er)
+                # Skip the next number since it's now part of this group
+                i += 2
+            else:
+                i += 1
+
+        return ers
+
+    @staticmethod
+    def __build_integer_er(num: ExtractResult) -> ExtractResult:
+        """Build a currency-typed ExtractResult for an integer number.
+
+        Wraps the number with a relative-position inner ExtractResult (start=0)
+        so the parser can extract the numeric value from the text.
+        """
+        inner = ExtractResult()
+        inner.start = 0
+        inner.length = num.length
+        inner.text = num.text
+        inner.type = num.type
+        inner.data = num.data
+
+        er = ExtractResult()
+        er.start = num.start
+        er.length = num.length
+        er.text = num.text
+        er.type = Constants.SYS_UNIT_CURRENCY
+        er.data = inner
+        return er

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
@@ -270,7 +270,7 @@ class NumberWithUnitExtractor(Extractor):
             if non_unit_match is None:
                 try:
                     non_unit_match = list(self.config.non_unit_regex.match(source))
-                except Exception:
+                except (TypeError, AttributeError):
                     non_unit_match = []
 
             self._extract_separate_units(source, result, non_unit_match)
@@ -717,53 +717,56 @@ class BaseMergedUnitExtractor(Extractor):
             if er.type != Constants.SYS_UNIT_CURRENCY:
                 continue
 
-            # Find a pure number that ends before this extraction starts
-            # and is separated only by a compound connector
-            for num in num_ers:
-                # The number must end before the currency extraction starts
-                num_end = num.start + num.length
-                if num_end >= er.start:
-                    continue
-
-                # Must be an integer
-                if not (isinstance(num.data, str) and num.data.startswith("Integer")):
-                    continue
-
-                # Ensure this number is not already covered by another extraction
-                is_covered = False
-                for other_er in ers:
-                    if other_er.start <= num.start and other_er.start + other_er.length >= num_end:
-                        is_covered = True
-                        break
-                if is_covered:
-                    continue
-
-                # Check if the text between the number and extraction is a connector
-                middle_str = source[num_end : er.start].strip().lower()
-                if not middle_str:
-                    continue
-
-                match = self.config.compound_unit_connector_regex.match(middle_str)
-                if match is None:
-                    continue
-                splitted_match = match.string.split(" ")
-                if not (match.pos == 0 and len(splitted_match[0]) == len(middle_str)):
-                    continue
-
-                # Merge: expand the extraction to include the preceding number
-                # and update data to be a compound list
-                int_er = self.__build_integer_er(num)
-                new_er = ExtractResult()
-                new_er.start = num.start
-                new_er.length = (er.start + er.length) - num.start
-                new_er.text = source[new_er.start : new_er.start + new_er.length]
-                new_er.type = Constants.SYS_UNIT_CURRENCY
-                new_er.data = [int_er, er]
-
-                modified_ers[idx] = new_er
-                break  # Only merge one preceding number per extraction
+            merged = self.__find_preceding_integer(source, num_ers, ers, er)
+            if merged:
+                modified_ers[idx] = merged
 
         return modified_ers
+
+    def __find_preceding_integer(
+        self, source: str, num_ers: List[ExtractResult], ers: List[ExtractResult], er: ExtractResult
+    ) -> ExtractResult:
+        """Find and merge a preceding integer connected by a compound connector."""
+        for num in num_ers:
+            num_end = num.start + num.length
+            if num_end >= er.start:
+                continue
+            if not (isinstance(num.data, str) and num.data.startswith("Integer")):
+                continue
+            if self.__is_covered_by_extraction(num, num_end, ers):
+                continue
+            if not self.__is_connector_between(source, num_end, er.start):
+                continue
+
+            int_er = self.__build_integer_er(num)
+            new_er = ExtractResult()
+            new_er.start = num.start
+            new_er.length = (er.start + er.length) - num.start
+            new_er.text = source[new_er.start : new_er.start + new_er.length]
+            new_er.type = Constants.SYS_UNIT_CURRENCY
+            new_er.data = [int_er, er]
+            return new_er
+
+        return None
+
+    @staticmethod
+    def __is_covered_by_extraction(num: ExtractResult, num_end: int, ers: List[ExtractResult]) -> bool:
+        """Check if a number is already covered by an existing extraction."""
+        for other_er in ers:
+            if other_er.start <= num.start and other_er.start + other_er.length >= num_end:
+                return True
+        return False
+
+    def __is_connector_between(self, source: str, start: int, end: int) -> bool:
+        """Check if text between two positions is a compound unit connector."""
+        middle_str = source[start:end].strip().lower()
+        if not middle_str:
+            return False
+        match = self.config.compound_unit_connector_regex.match(middle_str)
+        if match is None:
+            return False
+        splitted_match = match.string.split(" ")
+        return match.pos == 0 and len(splitted_match[0]) == len(middle_str)
 
     def __merge_connector_numbers(
         self, source: str, num_ers: List[ExtractResult], ers: List[ExtractResult]
@@ -779,52 +782,32 @@ class BaseMergedUnitExtractor(Extractor):
             current = num_ers[i]
             next_num = num_ers[i + 1]
 
-            # Check if current number data starts with "Integer"
             if not (isinstance(current.data, str) and current.data.startswith("Integer")):
                 i += 1
                 continue
 
-            middle_begin = current.start + current.length
-            middle_end = next_num.start
-            middle_str = source[middle_begin:middle_end].strip().lower()
-
-            if not middle_str:
+            if not self.__is_connector_between(source, current.start + current.length, next_num.start):
                 i += 1
                 continue
 
-            match = self.config.compound_unit_connector_regex.match(middle_str)
-            if match is not None:
-                splitted_match = match.string.split(" ")
-            else:
-                i += 1
-                continue
+            int_er = self.__build_integer_er(current)
 
-            if match and match.pos == 0 and len(splitted_match[0]) == len(middle_str):
-                # Create a compound currency extraction spanning both numbers
-                # and the connector. Store both numbers as a list in data so
-                # the downstream grouping treats this as a compound unit with
-                # an integer portion and a fractional portion.
-                int_er = self.__build_integer_er(current)
+            frac_er = ExtractResult()
+            frac_er.start = next_num.start
+            frac_er.length = next_num.length
+            frac_er.text = next_num.text
+            frac_er.type = Constants.SYS_NUM
+            frac_er.data = next_num.data
 
-                frac_er = ExtractResult()
-                frac_er.start = next_num.start
-                frac_er.length = next_num.length
-                frac_er.text = next_num.text
-                frac_er.type = Constants.SYS_NUM
-                frac_er.data = next_num.data
+            er = ExtractResult()
+            er.start = current.start
+            er.length = (next_num.start + next_num.length) - current.start
+            er.text = source[er.start : er.start + er.length]
+            er.type = Constants.SYS_UNIT_CURRENCY
+            er.data = [int_er, frac_er]
 
-                er = ExtractResult()
-                er.start = current.start
-                er.length = (next_num.start + next_num.length) - current.start
-                er.text = source[er.start : er.start + er.length]
-                er.type = Constants.SYS_UNIT_CURRENCY
-                er.data = [int_er, frac_er]
-
-                ers.append(er)
-                # Skip the next number since it's now part of this group
-                i += 2
-            else:
-                i += 1
+            ers.append(er)
+            i += 2
 
         return ers
 

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
@@ -211,65 +211,16 @@ class BaseCurrencyParser(Parser):
                 # the unit exists but simply lacks an ISO code (e.g., "Satoshi").
                 if not main_unit_iso_code:
                     if unit_value is None and idx + 1 < len(compound_unit):
-                        next_elem = compound_unit[idx + 1]
-                        if next_elem.type == Constants.SYS_NUM:
-                            # Merge the fractional part: next number / 100
-                            frac_result = next_elem
-                            frac_parse = self.number_with_unit_parser.parse(frac_result)
-                            frac_value = float(frac_parse.value) if frac_parse.value else 0
-                            number_value = number_value + frac_value * (1 / 100)
-                            result.length = frac_result.start + frac_result.length - result.start
-                            result.text = (
-                                compound_result.text[
-                                    result.start
-                                    - compound_result.start : result.start
-                                    - compound_result.start
-                                    + result.length
-                                ]
-                                if compound_result.start is not None
-                                else result.text
-                            )
-                            result.value = UnitValue(self.__get_number_value(number_value), main_unit_value)
-                            results.append(result)
+                        merged = self.__try_merge_connector_compound(
+                            compound_unit[idx + 1], compound_result, result, number_value
+                        )
+                        if merged:
+                            results.append(merged)
                             result = None
                             idx = idx + 2
                             count = 0
                             number_value = ''
                             continue
-                        elif next_elem.type == Constants.SYS_UNIT_CURRENCY:
-                            # Next element is a full currency extraction (e.g., "11 pesos").
-                            # Parse it to get its number and unit, then combine with
-                            # the preceding integer as: integer + fraction/100.
-                            next_parse = self.number_with_unit_parser.parse(next_elem)
-                            next_value = next_parse.value if next_parse else None
-                            if next_value and next_value.number:
-                                frac_value = float(next_value.number)
-                                number_value = number_value + frac_value * (1 / 100)
-                                merged_unit = next_value.unit
-                                merged_iso = self.config.currency_name_to_iso_code_map.get(merged_unit, None)
-                                result.length = next_elem.start + next_elem.length - result.start
-                                result.text = (
-                                    compound_result.text[
-                                        result.start
-                                        - compound_result.start : result.start
-                                        - compound_result.start
-                                        + result.length
-                                    ]
-                                    if compound_result.start is not None
-                                    else result.text
-                                )
-                                if merged_iso and not merged_iso.startswith(Constants.FAKE_ISO_CODE_PREFIX):
-                                    result.value = CurrencyUnitValue(
-                                        self.__get_number_value(number_value), merged_unit, merged_iso
-                                    )
-                                else:
-                                    result.value = UnitValue(self.__get_number_value(number_value), merged_unit)
-                                results.append(result)
-                                result = None
-                                idx = idx + 2
-                                count = 0
-                                number_value = ''
-                                continue
                     result.value = UnitValue(self.__get_number_value(number_value), main_unit_value)
                     results.append(result)
                     result = None
@@ -341,6 +292,53 @@ class BaseCurrencyParser(Parser):
         for parse_result in prs:
             if parse_result.start is not None and parse_result.length is not None:
                 parse_result.text = source[parse_result.start - bias : parse_result.start - bias + parse_result.length]
+
+    def __try_merge_connector_compound(self, next_elem, compound_result, result, number_value):
+        """Try to merge a following element as a fractional part of a connector compound.
+
+        Returns the merged result or None if merging is not applicable.
+        """
+        if next_elem.type == Constants.SYS_NUM:
+            return self.__merge_fraction_number(next_elem, compound_result, result, number_value)
+        if next_elem.type == Constants.SYS_UNIT_CURRENCY:
+            return self.__merge_fraction_currency(next_elem, compound_result, result, number_value)
+        return None
+
+    def __merge_fraction_number(self, frac_elem, compound_result, result, number_value):
+        """Merge a SYS_NUM element as a fractional part (e.g., '11' in '26663 con 11')."""
+        frac_parse = self.number_with_unit_parser.parse(frac_elem)
+        frac_value = float(frac_parse.value) if frac_parse.value else 0
+        number_value = number_value + frac_value * (1 / 100)
+        result.length = frac_elem.start + frac_elem.length - result.start
+        result.text = self.__resolve_compound_text(compound_result, result)
+        result.value = UnitValue(self.__get_number_value(number_value), None)
+        return result
+
+    def __merge_fraction_currency(self, next_elem, compound_result, result, number_value):
+        """Merge a currency element as a fractional part (e.g., '11 pesos' in '26663 con 11 pesos')."""
+        next_parse = self.number_with_unit_parser.parse(next_elem)
+        next_value = next_parse.value if next_parse else None
+        if not (next_value and next_value.number):
+            return None
+        frac_value = float(next_value.number)
+        number_value = number_value + frac_value * (1 / 100)
+        merged_unit = next_value.unit
+        merged_iso = self.config.currency_name_to_iso_code_map.get(merged_unit, None)
+        result.length = next_elem.start + next_elem.length - result.start
+        result.text = self.__resolve_compound_text(compound_result, result)
+        if merged_iso and not merged_iso.startswith(Constants.FAKE_ISO_CODE_PREFIX):
+            result.value = CurrencyUnitValue(self.__get_number_value(number_value), merged_unit, merged_iso)
+        else:
+            result.value = UnitValue(self.__get_number_value(number_value), merged_unit)
+        return result
+
+    @staticmethod
+    def __resolve_compound_text(compound_result, result):
+        """Resolve result text from the compound result source."""
+        if compound_result.start is not None:
+            offset = result.start - compound_result.start
+            return compound_result.text[offset : offset + result.length]
+        return result.text
 
     def __get_number_value(self, number_value):
         if number_value:

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
@@ -203,12 +203,14 @@ class BaseCurrencyParser(Parser):
                 result.resolution_str = parse_result.resolution_str
 
                 main_unit_iso_code = self.config.currency_name_to_iso_code_map.get(unit_value, None)
-                # If the main unit can't be recognized, check if the next element
-                # is a pure number or a currency extraction connected by a compound
-                # connector. If so, treat the current number as the integer portion
-                # and merge with the fractional part.
+                # If the main unit can't be recognized and there's no unit at all,
+                # check if the next element is a pure number or currency extraction
+                # connected by a compound connector. If so, treat the current number
+                # as the integer portion and merge with the fractional part.
+                # Only do this when unit_value is None (no unit detected), not when
+                # the unit exists but simply lacks an ISO code (e.g., "Satoshi").
                 if not main_unit_iso_code:
-                    if idx + 1 < len(compound_unit):
+                    if unit_value is None and idx + 1 < len(compound_unit):
                         next_elem = compound_unit[idx + 1]
                         if next_elem.type == Constants.SYS_NUM:
                             # Merge the fractional part: next number / 100

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
@@ -315,7 +315,10 @@ class BaseCurrencyParser(Parser):
         return result
 
     def __merge_fraction_currency(self, next_elem, compound_result, result, number_value):
-        """Merge a currency element as a fractional part (e.g., '11 pesos' in '26663 con 11 pesos')."""
+        """Merge a currency element as fractional part.
+
+        E.g., '11 pesos' in '26663 con 11 pesos'.
+        """
         next_parse = self.number_with_unit_parser.parse(next_elem)
         next_value = next_parse.value if next_parse else None
         if not (next_value and next_value.number):
@@ -327,7 +330,11 @@ class BaseCurrencyParser(Parser):
         result.length = next_elem.start + next_elem.length - result.start
         result.text = self.__resolve_compound_text(compound_result, result)
         if merged_iso and not merged_iso.startswith(Constants.FAKE_ISO_CODE_PREFIX):
-            result.value = CurrencyUnitValue(self.__get_number_value(number_value), merged_unit, merged_iso)
+            result.value = CurrencyUnitValue(
+                self.__get_number_value(number_value),
+                merged_unit,
+                merged_iso,
+            )
         else:
             result.value = UnitValue(self.__get_number_value(number_value), merged_unit)
         return result

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
@@ -9,7 +9,7 @@ from recognizers_number_with_unit.resources.base_currency import BaseCurrency
 from recognizers_text.extractor import Extractor, ExtractResult
 from recognizers_text.parser import Parser, ParseResult
 
-from .constants import *
+from .constants import Constants
 from .utilities import DictionaryUtility
 
 
@@ -76,6 +76,16 @@ class NumberWithUnitParser(Parser):
             i += 1
 
         # Unit type depends on last unit in suffix.
+        if not unit_keys:
+            # No unit text found — this is a pure number with no currency unit.
+            # Return a result with the parsed number value but no unit.
+            num_value = self.config.internal_number_parser.parse(number_result) if number_result.text else None
+            if num_value:
+                ret.value = UnitValue(number=num_value.resolution_str, unit=None)
+                ret.resolution_str = num_value.resolution_str
+            ret.text = ret.text.lower()
+            return ret
+
         last_unit = unit_keys[-1]
         if half_result and half_result.text in last_unit:
             last_unit = last_unit[: -1 * half_result.length]
@@ -163,7 +173,6 @@ class BaseCurrencyParser(Parser):
         number_value = ''
         main_unit_value = ''
         main_unit_iso_code = ''
-        fraction_unit_string = ''
 
         idx = 0
 
@@ -194,8 +203,71 @@ class BaseCurrencyParser(Parser):
                 result.resolution_str = parse_result.resolution_str
 
                 main_unit_iso_code = self.config.currency_name_to_iso_code_map.get(unit_value, None)
-                # If the main unit can't be recognized, finish process this group.
+                # If the main unit can't be recognized, check if the next element
+                # is a pure number or a currency extraction connected by a compound
+                # connector. If so, treat the current number as the integer portion
+                # and merge with the fractional part.
                 if not main_unit_iso_code:
+                    if idx + 1 < len(compound_unit):
+                        next_elem = compound_unit[idx + 1]
+                        if next_elem.type == Constants.SYS_NUM:
+                            # Merge the fractional part: next number / 100
+                            frac_result = next_elem
+                            frac_parse = self.number_with_unit_parser.parse(frac_result)
+                            frac_value = float(frac_parse.value) if frac_parse.value else 0
+                            number_value = number_value + frac_value * (1 / 100)
+                            result.length = frac_result.start + frac_result.length - result.start
+                            result.text = (
+                                compound_result.text[
+                                    result.start
+                                    - compound_result.start : result.start
+                                    - compound_result.start
+                                    + result.length
+                                ]
+                                if compound_result.start is not None
+                                else result.text
+                            )
+                            result.value = UnitValue(self.__get_number_value(number_value), main_unit_value)
+                            results.append(result)
+                            result = None
+                            idx = idx + 2
+                            count = 0
+                            number_value = ''
+                            continue
+                        elif next_elem.type == Constants.SYS_UNIT_CURRENCY:
+                            # Next element is a full currency extraction (e.g., "11 pesos").
+                            # Parse it to get its number and unit, then combine with
+                            # the preceding integer as: integer + fraction/100.
+                            next_parse = self.number_with_unit_parser.parse(next_elem)
+                            next_value = next_parse.value if next_parse else None
+                            if next_value and next_value.number:
+                                frac_value = float(next_value.number)
+                                number_value = number_value + frac_value * (1 / 100)
+                                merged_unit = next_value.unit
+                                merged_iso = self.config.currency_name_to_iso_code_map.get(merged_unit, None)
+                                result.length = next_elem.start + next_elem.length - result.start
+                                result.text = (
+                                    compound_result.text[
+                                        result.start
+                                        - compound_result.start : result.start
+                                        - compound_result.start
+                                        + result.length
+                                    ]
+                                    if compound_result.start is not None
+                                    else result.text
+                                )
+                                if merged_iso and not merged_iso.startswith(Constants.FAKE_ISO_CODE_PREFIX):
+                                    result.value = CurrencyUnitValue(
+                                        self.__get_number_value(number_value), merged_unit, merged_iso
+                                    )
+                                else:
+                                    result.value = UnitValue(self.__get_number_value(number_value), merged_unit)
+                                results.append(result)
+                                result = None
+                                idx = idx + 2
+                                count = 0
+                                number_value = ''
+                                continue
                     result.value = UnitValue(self.__get_number_value(number_value), main_unit_value)
                     results.append(result)
                     result = None

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.46"
+VERSION = "1.1.47a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.47a3"
+VERSION = "1.1.47"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.47a2"
+VERSION = "1.1.47a3"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.47a0"
+VERSION = "1.1.47a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number-with-unit/setup.py
+++ b/Python/libraries/recognizers-number-with-unit/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-with-unit-genesys"
-VERSION = "1.1.47a1"
+VERSION = "1.1.47a2"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.47a2"
+VERSION = "1.1.47a3"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.47a1"
+VERSION = "1.1.47a2"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.47a0"
+VERSION = "1.1.47a1"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.46"
+VERSION = "1.1.47a0"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-number/setup.py
+++ b/Python/libraries/recognizers-number/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-number-genesys"
-VERSION = "1.1.47a3"
+VERSION = "1.1.47"
 REQUIRES = ['recognizers-text-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.47a0"
+VERSION = "1.1.47a1"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.47a3"
+VERSION = "1.1.47"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.46"
+VERSION = "1.1.47a0"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.47a2"
+VERSION = "1.1.47a3"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-sequence/setup.py
+++ b/Python/libraries/recognizers-sequence/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 NAME = "recognizers-text-sequence-genesys"
-VERSION = "1.1.47a1"
+VERSION = "1.1.47a2"
 REQUIRES = ['recognizers-text-genesys', 'recognizers-text-number-genesys', 'regex']
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,15 +11,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.47a2'
+VERSION = '1.1.47a3'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.47a2',
-    'recognizers-text-number-genesys==1.1.47a2',
-    'recognizers-text-number-with-unit-genesys==1.1.47a2',
-    'recognizers-text-date-time-genesys==1.1.47a2',
-    'recognizers-text-sequence-genesys==1.1.47a2',
-    'recognizers-text-choice-genesys==1.1.47a2',
-    'datatypes_timex_expression_genesys==1.1.47a2',
+    'recognizers-text-genesys==1.1.47a3',
+    'recognizers-text-number-genesys==1.1.47a3',
+    'recognizers-text-number-with-unit-genesys==1.1.47a3',
+    'recognizers-text-date-time-genesys==1.1.47a3',
+    'recognizers-text-sequence-genesys==1.1.47a3',
+    'recognizers-text-choice-genesys==1.1.47a3',
+    'datatypes_timex_expression_genesys==1.1.47a3',
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,15 +11,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.47a0'
+VERSION = '1.1.47a1'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.47a0',
-    'recognizers-text-number-genesys==1.1.47a0',
-    'recognizers-text-number-with-unit-genesys==1.1.47a0',
-    'recognizers-text-date-time-genesys==1.1.47a0',
-    'recognizers-text-sequence-genesys==1.1.47a0',
-    'recognizers-text-choice-genesys==1.1.47a0',
-    'datatypes_timex_expression_genesys==1.1.47a0',
+    'recognizers-text-genesys==1.1.47a1',
+    'recognizers-text-number-genesys==1.1.47a1',
+    'recognizers-text-number-with-unit-genesys==1.1.47a1',
+    'recognizers-text-date-time-genesys==1.1.47a1',
+    'recognizers-text-sequence-genesys==1.1.47a1',
+    'recognizers-text-choice-genesys==1.1.47a1',
+    'datatypes_timex_expression_genesys==1.1.47a1',
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,15 +11,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.47a3'
+VERSION = '1.1.47'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.47a3',
-    'recognizers-text-number-genesys==1.1.47a3',
-    'recognizers-text-number-with-unit-genesys==1.1.47a3',
-    'recognizers-text-date-time-genesys==1.1.47a3',
-    'recognizers-text-sequence-genesys==1.1.47a3',
-    'recognizers-text-choice-genesys==1.1.47a3',
-    'datatypes_timex_expression_genesys==1.1.47a3',
+    'recognizers-text-genesys==1.1.47',
+    'recognizers-text-number-genesys==1.1.47',
+    'recognizers-text-number-with-unit-genesys==1.1.47',
+    'recognizers-text-date-time-genesys==1.1.47',
+    'recognizers-text-sequence-genesys==1.1.47',
+    'recognizers-text-choice-genesys==1.1.47',
+    'datatypes_timex_expression_genesys==1.1.47',
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,15 +11,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.47a1'
+VERSION = '1.1.47a2'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.47a1',
-    'recognizers-text-number-genesys==1.1.47a1',
-    'recognizers-text-number-with-unit-genesys==1.1.47a1',
-    'recognizers-text-date-time-genesys==1.1.47a1',
-    'recognizers-text-sequence-genesys==1.1.47a1',
-    'recognizers-text-choice-genesys==1.1.47a1',
-    'datatypes_timex_expression_genesys==1.1.47a1',
+    'recognizers-text-genesys==1.1.47a2',
+    'recognizers-text-number-genesys==1.1.47a2',
+    'recognizers-text-number-with-unit-genesys==1.1.47a2',
+    'recognizers-text-date-time-genesys==1.1.47a2',
+    'recognizers-text-sequence-genesys==1.1.47a2',
+    'recognizers-text-choice-genesys==1.1.47a2',
+    'datatypes_timex_expression_genesys==1.1.47a2',
 ]
 
 setup(

--- a/Python/libraries/recognizers-suite/setup.py
+++ b/Python/libraries/recognizers-suite/setup.py
@@ -11,15 +11,15 @@ def read(fname):
 
 
 NAME = 'recognizers-text-suite-genesys'
-VERSION = '1.1.46'
+VERSION = '1.1.47a0'
 REQUIRES = [
-    'recognizers-text-genesys==1.1.46',
-    'recognizers-text-number-genesys==1.1.46',
-    'recognizers-text-number-with-unit-genesys==1.1.46',
-    'recognizers-text-date-time-genesys==1.1.46',
-    'recognizers-text-sequence-genesys==1.1.46',
-    'recognizers-text-choice-genesys==1.1.46',
-    'datatypes_timex_expression_genesys==1.1.46',
+    'recognizers-text-genesys==1.1.47a0',
+    'recognizers-text-number-genesys==1.1.47a0',
+    'recognizers-text-number-with-unit-genesys==1.1.47a0',
+    'recognizers-text-date-time-genesys==1.1.47a0',
+    'recognizers-text-sequence-genesys==1.1.47a0',
+    'recognizers-text-choice-genesys==1.1.47a0',
+    'datatypes_timex_expression_genesys==1.1.47a0',
 ]
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.46"
+VERSION = "1.1.47a0"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.47a1"
+VERSION = "1.1.47a2"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.47a0"
+VERSION = "1.1.47a1"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.47a2"
+VERSION = "1.1.47a3"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 
 NAME = "recognizers-text-genesys"
-VERSION = "1.1.47a3"
+VERSION = "1.1.47"
 REQUIRES = ['emoji==1.1.0', 'multipledispatch']
 
 setup(

--- a/Specs/NumberWithUnit/Spanish/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Spanish/CurrencyModel.json
@@ -1914,5 +1914,86 @@
         "End": 24
       }
     ]
+  },
+  {
+    "Input": "26663 con 11",
+    "Comment": "Compound connector 'con' as decimal separator without currency prefix/suffix",
+    "NotSupported": "javascript, java, dotnet",
+    "Results": [
+      {
+        "Text": "26663 con 11",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "26663,11"
+        },
+        "Start": 0,
+        "End": 11
+      }
+    ]
+  },
+  {
+    "Input": "100 con 50",
+    "Comment": "Compound connector 'con' as decimal separator without currency unit",
+    "NotSupported": "javascript, java, dotnet",
+    "Results": [
+      {
+        "Text": "100 con 50",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "100,5"
+        },
+        "Start": 0,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "500 y 25",
+    "Comment": "Compound connector 'y' as decimal separator without currency unit",
+    "NotSupported": "javascript, java, dotnet",
+    "Results": [
+      {
+        "Text": "500 y 25",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "500,25"
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "26663 con 11 pesos",
+    "Comment": "Compound connector 'con' with currency suffix - merges preceding number as integer",
+    "NotSupported": "javascript, java, dotnet",
+    "Results": [
+      {
+        "Text": "26663 con 11 pesos",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "26663,11",
+          "unit": "Peso"
+        },
+        "Start": 0,
+        "End": 17
+      }
+    ]
+  },
+  {
+    "Input": "el monto es 1500 con 75",
+    "Comment": "Compound connector 'con' without currency unit in a sentence",
+    "NotSupported": "javascript, java, dotnet",
+    "Results": [
+      {
+        "Text": "1500 con 75",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "1500,75"
+        },
+        "Start": 12,
+        "End": 22
+      }
+    ]
   }
 ]


### PR DESCRIPTION
When a user enters "26663 con 11" with es-us/es-mx/es-es for an amountOfMoney entity, the system returned two separate values (26663.00 and 11.00) instead of the expected 26663.11. The compound unit connector regex ("con"/"y") only worked when a currency prefix/suffix was present (e.g., "$26663 con 11").

This fixes BaseMergedUnitExtractor.__merge_pure_number to detect consecutive integers separated by a compound connector and merge them as integer + fractional parts, even without a currency indicator. It also handles the case where a preceding number should merge into an already-detected currency extraction (e.g., "26663 con 11 pesos"). The parser's __merge_compound_unit was extended to resolve these new compound patterns into a single decimal value.